### PR TITLE
add support for `require_chef_omnibus` driver option

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -43,6 +43,8 @@ module Kitchen
       end
 
       def converge(state)
+        ssh_args = build_ssh_args(state)
+        install_omnibus(ssh_args) if config[:require_chef_omnibus]
         run "vagrant provision #{state[:hostname]}"
       end
 


### PR DESCRIPTION
This option works just like it does in `kitchen-ec2`. It ensures the 
desired version of Chef is installed via the official Opscode Omnibus 
client package. 

The main reason for adding this is to allow projects to use the official 
Canonical published Vagrant base boxes: 

http://uec-images.ubuntu.com/vagrant/

These base boxes do not ship with Chef pre-installed.

This change has been verified as working with the following `.kitchen.yml`:

``` yaml
driver_plugin: vagrant
platforms:
- name: ubuntu-12.10
  driver_config:
    box: canonical-ubuntu-12.10
    box_url: http://uec-images.ubuntu.com/vagrant/quantal/current/quantal-server-cloudimg-amd64-vagrant-disk1.box
    require_chef_omnibus: 11.4.0
  run_list:
  - recipe[apt]
- name: ubuntu-12.04
  driver_config:
    box: canonical-ubuntu-12.04
    box_url: http://uec-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-amd64-vagrant-disk1.box
    require_chef_omnibus: 11.4.0
  run_list:
  - recipe[apt]
suites:
- name: default
  run_list:
  - recipe[hubot]
  attributes: {}

```
