### PR TITLE
Conflicting versions on net-scp with kitchen and kitchen vagrant 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in kitchen-vagrant.gemspec
 gemspec
 
+gem 'net-scp', '~> 1.1.0'
 group :test do
   gem 'rake'
 end


### PR DESCRIPTION
Bundler could not find compatible versions for gem "net-scp":
  In Gemfile:
    kitchen-vagrant (>= 0) ruby depends on
      net-scp (~> 1.0.4) ruby

```
test-kitchen (>= 0) ruby depends on
  net-scp (1.1.0)
```
