### PR TITLE
Enable Berkshelf Vagrant plugin in Vagrantfile

### DIFF
--- a/lib/kitchen/vagrant/vagrantfile_creator.rb
+++ b/lib/kitchen/vagrant/vagrantfile_creator.rb
@@ -84,6 +84,7 @@ module Kitchen
 
       def berkshelf_block(arr)
         if File.exists?(berksfile)
+          arr << 'c.berkshelf.enabled = true'
           arr << %{  c.berkshelf.berksfile_path = "#{berksfile}"}
         end
       end


### PR DESCRIPTION
As of https://github.com/RiotGames/berkshelf-vagrant/commit/3dab4e137004002932cc8bc6e161318c281b03e4

Berkshelf needs `config.berkshelf.enabled = true` in `Vagrantfile` in order for it to work.
