### PR TITLE
Update Berkshelf plugin detection

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -150,10 +150,10 @@ module Kitchen
       def check_berkshelf_plugin
         if File.exists?(File.join(config[:kitchen_root], "Berksfile"))
           plugins = silently_run("vagrant plugin list").split("\n")
-          if ! plugins.find { |p| p =~ /^berkshelf-vagrant\b/ }
-            raise UserError, "Detected a Berksfile but the berksfile-vagrant" +
+          if ! plugins.find { |p| p =~ /^vagrant-berkshelf\b/ }
+            raise UserError, "Detected a Berksfile but the vagrant-berkshelf" +
               " plugin was not found in Vagrant. Please run:" +
-              " `vagrant plugin install berkshelf-vagrant' and retry."
+              " `vagrant plugin install vagrant-berkshelf' and retry."
           end
         end
       end


### PR DESCRIPTION
Berkshelf has recently renamed their Vagrant plugin which is already updated in master, but this detection of the old plugin will prevent a kitchen run.
