### PR TITLE
Config for private ssh key for Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,17 @@ installed. There are several different behaviors available:
 
 The default value is unset, or `nil`.
 
+### <a name="config-ssh-key"></a> ssh\_key
+This is the path to the private key file used for SSH authentication if you
+would like to use your own private ssh key instead of the default vagrant 
+insecure private key. 
+
+If this value is a relative path, then it will be expanded relative to the
+location of the main Vagrantfile. If this value is nil, then the default 
+insecure private key that ships with Vagrant will be used.
+
+The default value is unset, or `nil`.
+
 ## <a name="development"></a> Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/vagrant/vagrantfile_creator.rb
+++ b/lib/kitchen/vagrant/vagrantfile_creator.rb
@@ -50,6 +50,7 @@ module Kitchen
       def common_block(arr)
         arr << %{  c.vm.box = "#{config[:box]}"}
         arr << %{  c.vm.box_url = "#{config[:box_url]}"} if config[:box_url]
+        arr << %{  c.ssh.private_key_path = "#{config[:ssh_key]}"} if config[:ssh_key]
         arr << %{  c.vm.hostname = "#{instance.name}.vagrantup.com"}
       end
 


### PR DESCRIPTION
Will make it possible to configure your own private ssh key for vagrant instead of 
the default vagrant private key.

Will set the ssh_key in the Vagrantfile if the ssh_key attribute is set in .kitchen.yml
This didn't work before as in the config.merge(state) the setting in the .kitchen.yml
file is overriden by the setting in the Vagrantfile.

Has also added documentation for this configuration
