### PR TITLE
Allow to override Vagrant default SSH username

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ installed. There are several different behaviors available:
 
 The default value is unset, or `nil`.
 
+### <a name="config-username"></a> username
+
+This is the username used for SSH authentication if you
+would like to connect with a different account than Vagrant default user.
+
+If this value is nil, then Vagrant parameter `config.ssh.default.username`
+will be used (which is usually set to 'vagrant').
+
+The default value is unset, or `nil`.
+
 ## <a name="development"></a> Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/vagrant/vagrantfile_creator.rb
+++ b/lib/kitchen/vagrant/vagrantfile_creator.rb
@@ -51,6 +51,7 @@ module Kitchen
         arr << %{  c.vm.box = "#{config[:box]}"}
         arr << %{  c.vm.box_url = "#{config[:box_url]}"} if config[:box_url]
         arr << %{  c.vm.hostname = "#{instance.name}.vagrantup.com"}
+        arr << %{  c.ssh.username = "#{config[:username]}"} if config[:username]
       end
 
       def network_block(arr)


### PR DESCRIPTION
In complement to #23.
