### PR TITLE
add rackspace support

### DIFF
--- a/lib/kitchen/vagrant/vagrantfile_creator.rb
+++ b/lib/kitchen/vagrant/vagrantfile_creator.rb
@@ -70,6 +70,8 @@ module Kitchen
           virtualbox_customize(arr)
         when 'vmware_fusion', 'vmware_workstation'
           vmware_customize(arr)
+        when 'rackspace'
+          rackspace_customize(arr)
         end
         arr << %{  end}
       end
@@ -145,6 +147,12 @@ module Kitchen
           else
             arr << %{    p.vmx["#{key}"] = "#{value}"}
           end
+        end
+      end
+
+      def rackspace_customize(arr)
+        config[:customize].each do |key, value|
+          arr << %{    p.#{key} = "#{value}"}
         end
       end
 


### PR DESCRIPTION
Adds minimal rackspace support. Just add this to the top of your `.kitchen.yml`:

```

---
driver_plugin: vagrant
driver_config:
  use_vagrant_berkshelf_plugin: true
  provider: rackspace
  customize:
    username: <%= ENV['RS_USERNAME'] %>
    api_key: <%= ENV['RS_API_KEY'] %>
```
