### PR TITLE
add some quotes around Vagrantfile value

### DIFF
--- a/lib/kitchen/vagrant/vagrantfile_creator.rb
+++ b/lib/kitchen/vagrant/vagrantfile_creator.rb
@@ -138,7 +138,7 @@ module Kitchen
 
       def virtualbox_customize(arr)
         config[:customize].each do |key, value|
-          arr << %{    p.customize ["modifyvm", :id, "--#{key}", #{value}]}
+          arr << %{    p.customize ["modifyvm", :id, "--#{key}", "#{value}"]}
         end
       end
 


### PR DESCRIPTION
Quotes are missing around #{value} for virtualbox_customizer.  Without them, customizing any settings doesn't work.
