### PR TITLE
Add support for vagrant-cachier plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ truthy the opposite behvior will be used.
 
 The default is unset, or `nil`.
 
+### <a name="config-use-cachier-plugin"></a> use_cachier_plugin
+
+Determines whether or not this driver will use the vagrant-cachier Vagrant
+plugin to cache assets. If this value if falsey (`nil`, `false`) then the
+driver will skip the vagrant-cachier dependency check and not activate the
+plugin in the rendered Vagrantfile. If this value is truthy, the Vagrantfile
+will be populated with `cache.auto_detect` set to `true`.
+
+The default is unset, or `nil`.
+
 ### <a name="config-synced-folders"></a> synced_folders
 
 Allow the user to specify a collection of synced folders for on each Vagrant

--- a/lib/kitchen/vagrant/vagrantfile_creator.rb
+++ b/lib/kitchen/vagrant/vagrantfile_creator.rb
@@ -37,6 +37,7 @@ module Kitchen
         guest_block(arr)
         network_block(arr)
         provider_block(arr)
+        cachier_block(arr) if config[:use_cachier_plugin]
         chef_block(arr) if config[:use_vagrant_provision]
         berkshelf_block(arr) if config[:use_vagrant_berkshelf_plugin]
         synced_folders_block(arr)
@@ -81,6 +82,10 @@ module Kitchen
           rackspace_customize(arr)
         end
         arr << %{  end}
+      end
+
+      def cachier_block(arr)
+        arr << %{  c.cache.auto_detect = true}
       end
 
       def chef_block(arr)


### PR DESCRIPTION
This pull request adds basic support for the [vagrant-cachier](https://github.com/fgrehm/vagrant-cachier). There is no support for [scopes](https://github.com/fgrehm/vagrant-cachier#cache-scope) or targeting specific [buckets](https://github.com/fgrehm/vagrant-cachier#available-cache-buckets) yet.

Attempts to resolve #26.
