### PR TITLE
Allow all Vagrant's SSH Settings to be set in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,50 @@ will be used (which is usually set to 'vagrant').
 
 The default value is unset, or `nil`.
 
+### <a name="config-ssh"></a> ssh
+
+A **Hash** of customizations to Vagrants SSH settings used to access your box.
+Please read the [vagrantfile_ssh_settings][Vagrant SSH Settings] page for more
+informations.
+
+Available settings are:
+
+* `username`
+* `host`
+* `port`
+* `private_key_path`
+* `forward_agent`
+* `forward_x11`
+* `guest_port`
+* `keep_alive`
+* `max_tries`
+* `shell`
+* `timeout`
+
+There is **no** default value set.
+
+The Example:
+
+```ruby
+driver_config:
+  ssh:
+    forward_agent: true
+```
+
+Will enable agent forwarding over SSH connections.
+
+The "ssh.username" setting will get overwritten by the "username" setting when
+set. In this example:
+
+```ruby
+driver_config:
+  username: joe
+  ssh:
+    username: vagrant
+```
+
+the effective username setting will be "joe".
+
 ## <a name="development"></a> Development
 
 * Source hosted at [GitHub][repo]
@@ -298,6 +342,7 @@ Apache 2.0 (see [LICENSE][license])
 [vagrant_networking]:       http://docs.vagrantup.com/v2/networking/basic_usage.html
 [virtualbox_dl]:            https://www.virtualbox.org/wiki/Downloads
 [vagrantfile]:              http://docs.vagrantup.com/v2/vagrantfile/index.html
+[vagrantfile_ssh_settings]: http://docs.vagrantup.com/v2/vagrantfile/ssh_settings.html
 [vagrant_providers]:        http://docs.vagrantup.com/v2/providers/index.html
 [vagrant_wrapper]:          https://github.com/org-binbab/gem-vagrant-wrapper
 [vagrant_wrapper_background]: https://github.com/org-binbab/gem-vagrant-wrapper#background---aka-the-vagrant-gem-enigma

--- a/lib/kitchen/vagrant/vagrantfile_creator.rb
+++ b/lib/kitchen/vagrant/vagrantfile_creator.rb
@@ -36,6 +36,7 @@ module Kitchen
         common_block(arr)
         guest_block(arr)
         network_block(arr)
+        ssh_block(arr)
         provider_block(arr)
         chef_block(arr) if config[:use_vagrant_provision]
         berkshelf_block(arr) if config[:use_vagrant_berkshelf_plugin]
@@ -53,7 +54,6 @@ module Kitchen
         arr << %{  c.vm.box_url = "#{config[:box_url]}"} if config[:box_url]
         arr << %{  c.vm.synced_folder ".", "/vagrant", disabled: true}
         arr << %{  c.vm.hostname = "#{instance.name}.vagrantup.com"}
-        arr << %{  c.ssh.username = "#{config[:username]}"} if config[:username]
       end
 
       def guest_block(arr)
@@ -68,6 +68,19 @@ module Kitchen
           type = options.shift
           arr << %{  c.vm.network(:#{type}, #{options.join(", ")})}
         end
+      end
+
+      def ssh_block(arr)
+        ssh_config = config[:ssh]
+        if ssh_config
+          [:host, :port, :private_key_path, :forward_agent, :forward_x11,
+            :guest_port, :keep_alive, :max_tries, :shell, :timeout].each do |ssh_option|
+            arr << %{  c.ssh.#{ssh_option} = #{ssh_config[ssh_option].inspect}} if ssh_config.has_key? ssh_option
+          end
+          # backwards compatibility to top-level :username config
+          config[:username] = ssh_config[:username] if !config[:username] && ssh_config[:username]
+        end
+        arr << %{  c.ssh.username = "#{config[:username]}"} if config[:username]
       end
 
       def provider_block(arr)


### PR DESCRIPTION
Creates a new config sub-section `ssh` which reflects all of the  current Vagrant SSH Settings.
The current `username` config is still available and is preferred over `ssh.username`.
