### PR TITLE
Strip leading 'v' from Vagrant 1.3.0 version

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -168,7 +168,12 @@ module Kitchen
 
       def vagrant_version
         version_string = silently_run("vagrant --version")
-        version_string = version_string.chomp.split(" ").last.gsub(/^v/, '')
+
+        if match = version_string.match(/(\d+\.\d+\.\d+)/)
+          match[1]
+        else
+          raise UserError, "Vagrant version could not be determined."
+        end
       rescue Errno::ENOENT
         raise UserError, "Vagrant #{MIN_VER} or higher is not installed." +
           " Please download a package from #{WEBSITE}."


### PR DESCRIPTION
Vagrant 1.3.0's `vagrant --version` flag now outputs "Vagrant v1.3.0" instead
of the previous version's "Vagrant version 1.2.7"
