### PR TITLE
Add a option to use Vagrant plugin vagrant-cachier

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,16 @@ will be used (which is usually set to 'vagrant').
 
 The default value is unset, or `nil`.
 
+### <a name="config-use-vagrant-cachier"></a> use\_vagrant\_cachier
+
+Determines whether or not this driver will use the [vagrant-cachier][vagrant_cachier] Vagrant
+plugin to cache downloaded package files. If this value is falsey (`nil`,
+`false`) then the setup will not include the vagrant-cachier configuration line.
+
+Use `vagrant plugin install vagrant-cachier` to install the plugin.
+
+The default value is unset, or `nil`.
+
 ## <a name="development"></a> Development
 
 * Source hosted at [GitHub][repo]
@@ -304,3 +314,4 @@ Apache 2.0 (see [LICENSE][license])
 [vmware_plugin]:            http://www.vagrantup.com/vmware
 [fusion_dl]:                http://www.vmware.com/products/fusion/overview.html
 [workstation_dl]:           http://www.vmware.com/products/workstation/
+[vagrant_cachier]:          https://github.com/fgrehm/vagrant-cachier

--- a/lib/kitchen/vagrant/vagrantfile_creator.rb
+++ b/lib/kitchen/vagrant/vagrantfile_creator.rb
@@ -34,6 +34,7 @@ module Kitchen
         arr = []
         arr << %{Vagrant.configure("2") do |c|}
         common_block(arr)
+        cache_block(arr)
         guest_block(arr)
         network_block(arr)
         provider_block(arr)
@@ -54,6 +55,10 @@ module Kitchen
         arr << %{  c.vm.synced_folder ".", "/vagrant", disabled: true}
         arr << %{  c.vm.hostname = "#{instance.name}.vagrantup.com"}
         arr << %{  c.ssh.username = "#{config[:username]}"} if config[:username]
+      end
+
+      def cache_block(arr)
+        arr << %{  c.cache.auto_detect = "true"} if config[:use_vagrant_cachier]
       end
 
       def guest_block(arr)


### PR DESCRIPTION
This adds an option for vagrant_cachier, a plugin that speeds up provisioning via package caching.
