### PR TITLE
Allows nfs option for synced_folder

### DIFF
--- a/lib/kitchen/vagrant/vagrantfile_creator.rb
+++ b/lib/kitchen/vagrant/vagrantfile_creator.rb
@@ -110,8 +110,11 @@ module Kitchen
       end
 
       def synced_folders_block(arr)
-        config[:synced_folders].each do |source, destination|
-          arr << %{  c.vm.synced_folder "#{source}", "#{destination}" }
+        config[:synced_folders].each do |folder|
+          if folder.last.is_a?(Hash) && folder.last.has_key?(:nfs)
+            nfs_string = ", nfs: true"
+          end
+          arr << %{ c.vm.synced_folder "#{folder[0,2].join('", "')}"#{nfs_string}}
         end
       end
 


### PR DESCRIPTION
Patch adds support for nfs when using Vagrant's synced_folders.

Apologies, I'm not a rubyist so this is probably not the greatest code.
