### PR TITLE
Add additional disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,35 @@ Vagrant.configure("2") do |config|
 end
 ```
 
+### <a name="config-additional-disk"></a> additional_disk
+
+Allow the user to configure an additional disk for each Vagrant instance.
+
+The default configures no additional disk. This only works for virtualbox.
+
+```ruby
+drive_config
+  additional_disk:
+```
+
+or
+
+```ruby
+driver_config
+  additional_disk:
+    size: 50 # in GB, default is 20GB
+
+will generate a Vagrantfile configuration similar to:
+
+```ruby
+Vagrant.configure("2") do |config|
+    # ...
+
+    vb.customize ['createhd', '--filename', '/tmp/disk2.vdi', '--size', 50 * 1024]
+    vb.customize ['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', '/tmp/disk2.vdi']
+end
+```
+
 ### <a name="config-username"></a> username
 
 This is the username used for SSH authentication if you

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -29,6 +29,11 @@ Vagrant.configure("2") do |c|
 <% end %>
 
   c.vm.provider :<%= config[:provider] %> do |p|
+<% if config[:additional_disk] && config[:provider] == 'virtualbox' %>
+    <% disk_path = "/tmp/#{rand(36**50).to_s(36)}_disk2.vdi" %>
+    p.customize ['createhd', '--filename', '<%= disk_path %>', '--size', <%= config[:additional_disk][:size] || 20 %> * 1024]
+    p.customize ['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', '<%= disk_path %>']
+<% end %>
 <% config[:customize].each do |key, value| %>
   <% case config[:provider]
      when "virtualbox" %>


### PR DESCRIPTION
This change should allow you to configure an additional disk in
vagrant. This is good for testing cookbooks that manipulate
disks. Like in my case where i'm trying to build a cryptsetup
cookbook.
