### PR TITLE
Add vb_customize to extend customizations for virtualbox

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -33,6 +33,11 @@ Vagrant.configure("2") do |c|
   <% case config[:provider]
      when "virtualbox" %>
     p.customize ["modifyvm", :id, "--<%= key %>", "<%= value %>"]
+       <% if config[:vb_customize] %>
+         <% config[:vb_customize].each do |c| %>
+           p.customize <%= c.split(/\s*,\s*/).map{|x| x =~ /^:/ ? x.gsub(/^:/,'').to_sym : x}.to_s %>
+         <% end %>
+       <% end %>
   <% when "rackspace" %>
     p.<%= key %> = "<%= value%>"
   <% when /^vmware_/ %>


### PR DESCRIPTION
In order to handle more complex virtualbox configurations have added
vb_customize to driver_config.  This allows you to add the following
example:

```
driver:
  vb_customize:
    - modifyvm, :id, --memory, 4048
    - modifyvm, :id, --nic2, intnet
```

To generate:

```
  Vagrant.configure("2") do |config|
    # ...

    config.vm.provider :virtualbox do |virtualbox|
      virtualbox.customize ["modifyvm", :id, "--memory", "4048"]
      virtualbox.customize ["modifyvm", :id, "--nic2", "intnet"]
    end
  end
```

You can also use other VBoxManage commands outside of modifyvm (e.g. createhd,
storageattach, etc).
