### PR TITLE
Remove default memory setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ platforms:
 # ...
 ```
 
+Many host wide defaults for Vagrant can be set using `$HOME/.vagrant.d/Vagrantfile`. See the [Vagrantfile documentation][vagrantfile] for more information.
+
 ## <a name="config"></a> Configuration
 
 ### <a name="config-box"></a> box
@@ -142,11 +144,7 @@ Vagrant.configure("2") do |config|
 end
 ```
 
-Please read the [Vagrantfile configuration][vagrantfile] page for
-more details.
-
-By default, each Vagrant virtual machine is configured with 256 MB of RAM. In
-other words the default value for `customize` is `{:memory => '256'}`.
+Please read the "Customizations" sections for [VirtualBox][vagrant_config_vbox] and [VMware][vagrant_config_vmware] for more details.
 
 ### <a name="config-dry-run"></a> dry\_run
 
@@ -323,6 +321,8 @@ Apache 2.0 (see [LICENSE][license])
 [vagrant_networking]:       http://docs.vagrantup.com/v2/networking/basic_usage.html
 [virtualbox_dl]:            https://www.virtualbox.org/wiki/Downloads
 [vagrantfile]:              http://docs.vagrantup.com/v2/vagrantfile/index.html
+[vagrant_config_vbox]:      http://docs.vagrantup.com/v2/virtualbox/configuration.html
+[vagrant_config_vmware]:    http://docs.vagrantup.com/v2/vmware/configuration.html
 [vagrant_providers]:        http://docs.vagrantup.com/v2/providers/index.html
 [vagrant_wrapper]:          https://github.com/org-binbab/gem-vagrant-wrapper
 [vagrant_wrapper_background]: https://github.com/org-binbab/gem-vagrant-wrapper#background---aka-the-vagrant-gem-enigma

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -33,7 +33,7 @@ module Kitchen
     #   dependency hook checks when feature is released
     class Vagrant < Kitchen::Driver::SSHBase
 
-      default_config :customize, { :memory => '256' }
+      default_config :customize, {}
       default_config :network, []
       default_config :synced_folders, []
       default_config :pre_create_command, nil


### PR DESCRIPTION
The memory setting overrides the default specified both by the box and in global `~/.vagrant.d/Vagrantfile`. Most Vagrant base boxes (including [Bento](https://github.com/opscode/bento) boxes) default to 386 MB, which should be fine for normal Test Kitchen usage. And removing the default allows users to set their own host-wide default.

Ref: #22
