### PR TITLE
Return use_vagrant_provision for windows os

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -72,7 +72,11 @@ module Kitchen
 
       def converge(state)
         create_vagrantfile
-        super
+        if config[:use_vagrant_provision]
+          run "vagrant provision"
+        else
+          super
+        end
       end
 
       def setup(state)


### PR DESCRIPTION
I am sure there is good reason that this configuration option was removed and so feel free to silence me and my infernal quibblings.  But I saw some complaints about it missing and we use windows and kitchen so we added it back..... :wolf: 
