### PR TITLE
Support vagrant-softlayer plugin syntax

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -33,7 +33,7 @@ Vagrant.configure("2") do |c|
   <% case config[:provider]
      when "virtualbox" %>
     p.customize ["modifyvm", :id, "--<%= key %>", "<%= value %>"]
-  <% when "rackspace" %>
+  <% when "rackspace", "softlayer" %>
     p.<%= key %> = "<%= value%>"
   <% when /^vmware_/ %>
     <% if key == :memory %>


### PR DESCRIPTION
Enable support for [vagrant-softlayer](https://github.com/audiolize/vagrant-softlayer)'s Vagrantfile syntax:

`.kitchen.yml`:

```

---
driver:
  name: vagrant
  provider: softlayer
  customize:
    username: <%= ENV['SL_API_USERNAME'] %>
    api_key:  <%= ENV['SL_API_KEY'] %>
    #...
```

Configuration generated:

```
Vagrant.configure("2") do |config|
  config.vm.provider :softlayer do |sl|
    sl.username = '...'
    sl.api_key  = '...'
  end
end
```
