### PR TITLE
Add support for a post_create_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,19 @@ pre_create_command: cp .vagrant_plugins.json {{vagrant_root}}/ && vagrant plugin
 
 The default is unset, or `nil`.
 
+### <a name="config-post-create-command"></a> post\_create\_command
+
+An optional hook to run a command immediately after the
+`vagrant up --no-provisioner` command is executed.
+
+There is an optional token, `{{vagrant_root}}` that can be used in the
+`post_create_command` string which will be expanded by the driver to be the full
+path to the sandboxed Vagrant root directory containing the Vagrantfile. This
+command will be executed from the directory containing the .kitchen.yml file,
+or the `kitchen_root`.
+
+The default is unset, or `nil`.
+
 ### <a name="config-synced-folders"></a> synced_folders
 
 Allow the user to specify a collection of synced folders on each Vagrant

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -68,6 +68,7 @@ module Kitchen
         run cmd
         set_ssh_state(state)
         info("Vagrant instance #{instance.to_str} created.")
+        run_post_create_command
       end
 
       def converge(state)
@@ -131,6 +132,12 @@ module Kitchen
       def run_pre_create_command
         if config[:pre_create_command]
           run(config[:pre_create_command], :cwd => config[:kitchen_root])
+        end
+      end
+
+      def run_post_create_command
+        if config[:post_create_command]
+          run(config[:post_create_command], :cwd => config[:kitchen_root])
         end
       end
 
@@ -212,6 +219,10 @@ module Kitchen
         unless config[:pre_create_command].nil?
           config[:pre_create_command] =
             config[:pre_create_command].gsub("{{vagrant_root}}", vagrant_root)
+        end
+        unless config[:post_create_command].nil?
+          config[:post_create_command] =
+            config[:post_create_command].gsub("{{vagrant_root}}", vagrant_root)
         end
       end
 


### PR DESCRIPTION
There is already a `pre_create_command` that executes a custom command prior to the `vagrant up` command. This pull request adds support for a `post_create_command` as well.

I believe supplying something like `vagrant ssh -c 'some command'` to `post_create_command` could resolve https://github.com/test-kitchen/kitchen-vagrant/issues/78.
