### PR TITLE
Add support to customize Parallels Vagrantfile

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -29,6 +29,8 @@ Vagrant.configure("2") do |c|
   <% case config[:provider]
      when "virtualbox" %>
     p.customize ["modifyvm", :id, "--<%= key %>", "<%= value %>"]
+  <% when "parallels" %>
+    p.customize ["set", :id, "--<%= key.to_s.gsub('_', '-') %>", "<%= value %>"]
   <% when "rackspace", "softlayer" %>
     p.<%= key %> = "<%= value%>"
   <% when /^vmware_/ %>


### PR DESCRIPTION
- convert key from snake_case to dash-case (prevents ugly yaml using
  quoted keys)
- the customize hash below should be considered as a default to allow one to
  close the vm window if Parallels Desktop is open

File: `.kitchen.yml`:

``` yaml
- name: parallels-vm
  driver:
    provider: parallels
    box: parallels/centos-65
    customize:
      on_window_close: keep-running
```

converts to file: `.kitchen/kitchen-vagrant/<name>/Vagrantfile`:

``` ruby
 c.vm.provider :parallels do |p|
   p.customize ["set", :id, "--on-window-close", "keep-running"]
 end
```
