### PR TITLE
Updated default Vagrantfile template

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,15 @@ If this value is a relative path, then it will be expanded relative to the
 location of the main Vagrantfile. If this value is nil, then the default
 insecure private key that ships with Vagrant will be used.
 
+You can also specify multiple private keys by setting this to be an array.
+
+For more details please read the [config.ssh](http://docs.vagrantup.com/v2/vagrantfile/ssh_settings.html) section of the Vagrant documentation.
+
 The default value is unset, or `nil`.
+
+### <a name="config-ssh-forward-agent"></a> ssh\_forward\_agent
+
+When set to true agent forwarding over SSH connection is enabled.
 
 ## <a name="development"></a> Development
 

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -12,7 +12,10 @@ Vagrant.configure("2") do |c|
   c.ssh.username = "<%= config[:username] %>"
 <% end %>
 <% if config[:ssh_key] %>
-  c.ssh.private_key_path = "<%= config[:ssh_key] %>"
+  c.ssh.private_key_path = <%= Array(config[:ssh_key]) %>
+<% end %>
+<% if config[:ssh_forward_agent] %>
+  c.ssh.forward_agent = <%= config[:ssh_forward_agent] %>
 <% end %>
 
 <% Array(config[:network]).each do |opts| %>


### PR DESCRIPTION
I need to generate following Vagrant config:

``` ruby
  c.ssh.private_key_path = ["~/.ssh/id_rsa", "~/.vagrant.d/insecure_private_key"]
  c.ssh.forward_agent = true
```

This is required if I want to pull git repository on the VM, using keys from the host. Vagrant allows setting  array of private keys path (see [comit](https://github.com/mitchellh/vagrant/commit/45e09eb6778fd22d7d6cabae65f476d9f8035873)). Therefore kitchen-vagrant should also support without having to use custom Vagrantfile template.

I've also added `:ssh_forward_agent` option which maps to `config.ssh.forward_agent` in Vagrant, which seems to be used very often with `private_key_path` setting.

With this change user will be able to setup driver like this:

``` yml
driver:
  name: vagrant
  ssh_agent: true
  ssh_key: ['~/.ssh/id_rsa', '~/.vagrant.d/insecure_private_key']
  ..
```

What do you think?
