### PR TITLE
Add SSH ProxyCommand to state if present

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -185,6 +185,7 @@ module Kitchen
         state[:username] = hash["User"]
         state[:ssh_key] = hash["IdentityFile"]
         state[:port] = hash["Port"]
+        state[:proxy_command] = hash["ProxyCommand"] if hash["ProxyCommand"]
       end
 
       def vagrant_ssh_config


### PR DESCRIPTION
If vagrant ssh-config includes "ProxyCommand", add `:proxy_command` to machine state in order to allow proxied SSH connectivity from test-kitchen.

See test-kitchen/test-kitchen#426 for details; depends on that PR being merged to be useful.
