### PR TITLE
Qualify VM names with cookbook name

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -136,7 +136,8 @@ module Kitchen
 
       def vagrant_root
         @vagrant_root ||= File.join(
-          config[:kitchen_root], %w{.kitchen kitchen-vagrant}, instance.name
+          config[:kitchen_root], %w{.kitchen kitchen-vagrant},
+          "kitchen-#{File.basename(config[:kitchen_root])}-#{instance.name}"
         )
       end
 


### PR DESCRIPTION
VirtualBox names VMs after the base name of the current directory, which
results in names like default-centos-65_default_..., which are not very
helpful when looking at a process list or working in the VirtualBox GUI,
especially when working with several cookbooks at once.

Change the working directory name created by kitchen-vagrant to look
like

```
kitchen-${cookbook}-${rest as before}
```

to make things clearer.  (${cookbook} is actually just the name of the
root directory for Test Kitchen, but that's usually a cookbook name.)
