### PR TITLE
Support box_version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ The default will be computed from the platform name of the instance.
 
 The [version][vagrant_versioning] of the configured box.
 
+### <a name="config-box-check-update"></a> box\_check\_update
+
+Whether to check for box updates (enabled by default).
+
 ### <a name="config-provider"></a> provider
 
 This determines which Vagrant provider to use. The value should match

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -57,6 +57,7 @@ module Kitchen
       end
 
       default_config :box_version, nil
+      default_config :box_check_update, nil
 
       required_config :box
 

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -4,6 +4,9 @@ Vagrant.configure("2") do |c|
 <% if config[:box_version] %>
   c.vm.box_version = "<%= config[:box_version] %>"
 <% end %>
+<% if config[:box_check_update] %>
+  c.vm.box_check_update = "<%= config[:box_check_update] %>"
+<% end %>
 
 <% if config[:vm_hostname] %>
   c.vm.hostname = "<%= config[:vm_hostname] %>"


### PR DESCRIPTION
Vagrant has supported [box versioning](https://docs.vagrantup.com/v2/boxes/versioning.html) since v1.5. Although it doesn't seem to be well documented, it's actually possible to set `box_url` to a [metadata file](https://docs.vagrantup.com/v2/boxes/format.html) rather than a specific box. This PR makes kitchen-vagant support Vagrant's [box_version](http://docs.vagrantup.com/v2/vagrantfile/machine_settings.html) option, without which, Vagrant will default to using the latest version. 

This will be very useful to teams who have a large number of proprietary Chef cookbook repositories. Now instead of having to update the `.kitchen.yml` in every repo for every new base box update, it'll be possible to do global updates through a single metadata file hosted on a server.
