### PR TITLE
Add support for generating vm.communicator so winrm can be specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,26 @@ started.
 
 The default will be computed from the platform name of the instance.
 
+
+### <a name="config-communicator"></a> communicator
+
+For supporting communicating with Windows over WinRM.  
+
+For example:
+
+```ruby
+driver:
+  communicator: "winrm"
+```
+
+will generate a Vagrantfile configuration similar to:
+
+```ruby
+  config.vm.communicator = "winrm"
+```
+
+The default is nil assuming ssh will be used.
+
 ### <a name="config-provider"></a> provider
 
 This determines which Vagrant provider to use. The value should match

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -2,6 +2,9 @@ Vagrant.configure("2") do |c|
   c.vm.box = "<%= config[:box] %>"
   c.vm.box_url = "<%= config[:box_url] %>"
 
+<% if config[:communicator] %>
+    c.vm.communicator = "<%= config[:communicator] %>"
+<% end %>
 <% if config[:vm_hostname] %>
   c.vm.hostname = "<%= config[:vm_hostname] %>"
 <% end %>


### PR DESCRIPTION
Vagrant 1.6 added support for winrm so you don't have to setup ssh in windows.

https://www.vagrantup.com/blog/feature-preview-vagrant-1-6-windows.html
