### PR TITLE
Default hostname using FQDN make vagrant fail with windows guest

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -45,7 +45,7 @@ module Kitchen
         ENV.fetch('VAGRANT_DEFAULT_PROVIDER', "virtualbox")
 
       default_config :vm_hostname do |driver|
-        "#{driver.instance.name}.vagrantup.com"
+        driver.instance.name
       end
 
       default_config :box do |driver|


### PR DESCRIPTION
Since vagrant 1.6.4 vagrant fails to setup windows guest with FQDN as hostname because it exceed the 15 characters limit.
Even some Linux systems do not recommend to use FQDN as hostname.

If needed, I can add a test on the "guest" property to use FQDN on all guest which are not windows.
