### PR TITLE
config.ssh.pty support

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -17,6 +17,9 @@ Vagrant.configure("2") do |c|
 <% if config[:ssh_key] %>
   c.ssh.private_key_path = "<%= config[:ssh_key] %>"
 <% end %>
+<% if config[:pty] %>
+  c.ssh.pty = "<%= config[:pty] %>"
+<% end %>
 
 <% Array(config[:network]).each do |opts| %>
   c.vm.network(:<%= opts[0] %>, <%= opts[1..-1].join(", ") %>)


### PR DESCRIPTION
Main reason for introducing control over this configuration option
is a 'Defaults requiretty' in /etc/sudoers of RHEL/Centos/ScientificLinux.

See
https://github.com/mitchellh/vagrant/issues/1482#issuecomment-30099245
