### PR TITLE
Added ssh config hash

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -36,6 +36,7 @@ module Kitchen
       default_config :customize, {}
       default_config :network, []
       default_config :synced_folders, []
+      default_config :ssh, {} 
       default_config :pre_create_command, nil
 
       default_config :vagrantfile_erb,

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -18,6 +18,10 @@ Vagrant.configure("2") do |c|
   c.ssh.private_key_path = "<%= config[:ssh_key] %>"
 <% end %>
 
+<% config[:ssh].each do |key, value| %>
+  c.ssh.<%= key %> = <%= value %>
+<% end %>
+
 <% Array(config[:network]).each do |opts| %>
   c.vm.network(:<%= opts[0] %>, <%= opts[1..-1].join(", ") %>)
 <% end %>


### PR DESCRIPTION
Currently there are only options to add specific ssh parameters to the config.

This change allows one to set any ssh parameter from kitchen file.

the kitchen file config can then  look like this:

``` yml
driver:
    name: vagrant
    customize:
      memory: 2048
      cpus: 2
    ssh:
      forward_agent: true
      username: "customUser"
      port: 4313
```

With this change, current explicit setters for username, password and private_key_path can be removed.

Any thoughts?
