### PR TITLE
Make box_url optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,13 @@ This will effectively generate a configuration similar to:
 platforms:
 - name: ubuntu-10.04
   driver:
-    box: opscode-ubuntu-10.04
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_provisionerless.box
+    box: chef/ubuntu-10.04
 - name: ubuntu-12.04
   driver:
-    box: opscode-ubuntu-12.04
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
+    box: chef/ubuntu-12.04
 - name: ubuntu-12.10
   driver:
-    box: opscode-ubuntu-12.10
-    box_url: ...
+    box: chef/ubuntu-12.10
 # ...
 ```
 
@@ -96,17 +93,18 @@ Many host wide defaults for Vagrant can be set using `$HOME/.vagrant.d/Vagrantfi
 details, please read the Vagrant [machine settings][vagrant_machine_settings]
 page.
 
+It is recommended to use a short name of a box on Vagrant Cloud and leave
+box_url empty if your box is publically available.
+
 The default will be computed from the platform name of the instance. For
 example, a platform called "fuzzypants-9.000" will produce a default `box`
-value of `"opscode-fuzzypants-9.000"`.
+value of `"chef/fuzzypants-9.000"`.
 
 ### <a name="config-box-url"></a> box\_url
 
-The URL that the configured box can be found at. If the box is not installed on
-the system, it will be retrieved from this URL when the virtual machine is
-started.
-
-The default will be computed from the platform name of the instance.
+The URL that the configured box can be found at if not available on the
+Vagrant Cloud or if on Vagrant < 1.5. If the box is not installed on the
+system, it will be retrieved from this URL when the virtual machine is started.
 
 ### <a name="config-provider"></a> provider
 

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -106,6 +106,10 @@ module Kitchen
       end
 
       def default_box_url
+
+        # No default neede for 1.5 onwards - Vagrant Cloud only needs a box name
+        return if Gem::Version.new(vagrant_version) >= Gem::Version.new(1.5)
+
         bucket = config[:provider]
         bucket = 'vmware' if config[:provider] =~ /^vmware_(.+)$/
 

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -1,6 +1,8 @@
 Vagrant.configure("2") do |c|
   c.vm.box = "<%= config[:box] %>"
+<% if config[:box_url] %>
   c.vm.box_url = "<%= config[:box_url] %>"
+<% end %>
 
 <% if config[:vm_hostname] %>
   c.vm.hostname = "<%= config[:vm_hostname] %>"


### PR DESCRIPTION
Vagrant 1.5 doesn’t need it anymore, just the name from the Vagrant cloud
