### PR TITLE
Add LXC provider support to kitchen-vagrant

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -57,7 +57,9 @@ Vagrant.configure("2") do |c|
   <% when "parallels" %>
     p.customize ["set", :id, "--<%= key.to_s.gsub('_', '-') %>", "<%= value %>"]
   <% when "lxc" %>
-    <% if [:container_name, :backingstore, :backingstore_option].include? key %>
+    <% if key == :container_name %>
+    p.<%= key %> = <%= value == ":machine" ? value : "\"#{value}\"" %>
+    <% elsif key == :backingstore %>
     p.<%= key %> = "<%= value %>"
     <% else %>
     p.customize "<%= key %>", "<%= value %>"

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -56,6 +56,12 @@ Vagrant.configure("2") do |c|
     p.customize ["modifyvm", :id, "--<%= key %>", "<%= value %>"]
   <% when "parallels" %>
     p.customize ["set", :id, "--<%= key.to_s.gsub('_', '-') %>", "<%= value %>"]
+  <% when "lxc" %>
+    <% if [:container_name, :backingstore, :backingstore_option].include? key %>
+    p.<%= key %> = "<%= value %>"
+    <% else %>
+    p.customize "<%= key %>", "<%= value %>"
+    <% end %>
   <% when "rackspace", "softlayer" %>
     p.<%= key %> = "<%= value%>"
   <% when "libvirt" %>

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -61,8 +61,10 @@ Vagrant.configure("2") do |c|
     p.container_name = <%= value == ":machine" ? value : "\"#{value}\"" %>
     <% elsif key == :backingstore %>
     p.backingstore = "<%= value %>"
-    <% elsif key == :backingstore_option %>
-    p.backingstore_option <%= value %>
+    <% elsif key == :backingstore_options %>
+      <% config[:customize][:backingstore_options].each do |opt, opt_val| %>
+    p.backingstore_option "--<%= opt %>", "<%= opt_val %>"
+      <% end %>
     <% else %>
     p.customize "<%= key %>", "<%= value %>"
     <% end %>

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -58,9 +58,11 @@ Vagrant.configure("2") do |c|
     p.customize ["set", :id, "--<%= key.to_s.gsub('_', '-') %>", "<%= value %>"]
   <% when "lxc" %>
     <% if key == :container_name %>
-    p.<%= key %> = <%= value == ":machine" ? value : "\"#{value}\"" %>
+    p.container_name = <%= value == ":machine" ? value : "\"#{value}\"" %>
     <% elsif key == :backingstore %>
-    p.<%= key %> = "<%= value %>"
+    p.backingstore = "<%= value %>"
+    <% elsif key == :backingstore_option %>
+    p.backingstore_option <%= value %>
     <% else %>
     p.customize "<%= key %>", "<%= value %>"
     <% end %>


### PR DESCRIPTION
This PR add support for the [vagrant-lxc](https://github.com/fgrehm/vagrant-lxc) provider customizations in the `Vagrantfile.erb` template.

Use it in `.kitchen.yml` like this (assuming that lxc is the [VAGRANT_DEFAULT_PROVIDER](https://docs.vagrantup.com/v2/providers/default.html)):
```yaml
---
driver:
  name: vagrant

platforms:
- name: ubuntu-12.04
  driver_config:
    box: 'fgrehm/precise64-lxc'
    customize:
      container_name: 'mysql'
      cgroup.memory.limit_in_bytes: '128M'
      cgroup.cpuset.cpus: '0,1'
      backingstore: 'lvm'
      backingstore_options: { vgname: 'schroots', fstype: 'xfs', fssize: '5G' }
```

It will generate a Vagrantfile like this:
```ruby
Vagrant.configure("2") do |c|
  c.vm.box = "fgrehm/precise64-lxc"
  c.vm.hostname = "default-ubuntu-1204"
  c.vm.synced_folder ".", "/vagrant", disabled: true
  c.vm.provider :lxc do |p|
    p.container_name = 'mysql'
    p.customize "cgroup.memory.limit_in_bytes", "128M"
    p.customize "cgroup.cpuset.cpus", "0,1"
    p.backingstore = "lvm"
    p.backingstore_option "--vgname", "schroots"
    p.backingstore_option "--fstype", "xfs"
    p.backingstore_option "--fssize", "5G"
  end
end
```

Considerations:

 * if the container name is `":machine"` it will be added as `:machine` in the Vagrantfile (don't know if there is a way to explicitly represent symbols in YAML)
 * all the other options should be quite self explanatory given the example above. For a reference of the available configuration options see https://github.com/fgrehm/vagrant-lxc/blob/master/README.md#advanced-configuration

/cc @fgrehm
