### PR TITLE
Provision option

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,11 @@ driver:
     - /tmp/VagrantfileB.rb
 ```
 
+### <a name="provision"></a> provision
+
+Set to true if you want to do the provision of vagrant in create.
+Usefull in case of you want to customize the OS in provision phase of vagrant
+
 ## <a name="development"></a> Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -39,6 +39,7 @@ module Kitchen
       default_config :ssh, {}
       default_config :pre_create_command, nil
       default_config :vagrantfiles, []
+      default_config :provision, false
 
       default_config :vagrantfile_erb,
         File.join(File.dirname(__FILE__), "../../../templates/Vagrantfile.erb")
@@ -68,7 +69,8 @@ module Kitchen
       def create(state)
         create_vagrantfile
         run_pre_create_command
-        cmd = "vagrant up --no-provision"
+        cmd = "vagrant up"
+        cmd += " --no-provision" unless config[:provision]
         cmd += " --provider=#{config[:provider]}" if config[:provider]
         run cmd
         set_ssh_state(state)


### PR DESCRIPTION
Able to run vagrant up if we set the provision flad
Needed in case of you want to include a vagrantfile like this

```ruby
Vagrant.configure(2) do |config|
    config.vm.provision :shell do |shell|
    shell.inline = %Q{
    
    }
  end
end
```