### PR TITLE
Support SoftLayer disk_capacity configuration

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -56,7 +56,13 @@ Vagrant.configure("2") do |c|
     p.customize ["modifyvm", :id, "--<%= key %>", "<%= value %>"]
   <% when "parallels" %>
     p.customize ["set", :id, "--<%= key.to_s.gsub('_', '-') %>", "<%= value %>"]
-  <% when "rackspace", "softlayer" %>
+  <% when "softlayer" %>
+    <% if key == :disk_capacity %>
+    p.<%= key %> = <% value %>
+    <% else %>
+    p.<%= key %> = "<% value %>"
+    <% end %>    
+  <% when "rackspace" %>
     p.<%= key %> = "<%= value%>"
   <% when "libvirt" %>
     p.<%= key %> = <%= value%>


### PR DESCRIPTION
This adds support for specifying the disk_capacity hash in your .kitchen.yml in the form of the following:

    ---
    driver:
      name: vagrant
      provider: softlayer
      customize:
         disk_capacity:
           "0": 25
           "2": 100

We need to prevent enclosing the hash in quotes due to the conversion to a symbolized_hash. The above would result in the following invalid Vagrantfile otherwise:

    p.disk_capacity = "{:"0"=>25, :"2"=>100}"