### PR TITLE
Add support for managed-servers Vagrant provider

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -68,6 +68,10 @@ Vagrant.configure("2") do |c|
     <% else %>
     p.vmx["<%= key %>"] = "<%= value %>"
     <% end %>
+  <% when "managed" %>
+    <% if key == :server %>
+    p.server = "<%= value %>"
+    <% end %>
   <% end %>
 <% end %>
   end


### PR DESCRIPTION
This simple addition to the Vagrantfile template is enough to add support for the managed-servers Vagrant provider (https://github.com/tknerr/vagrant-managed-servers).  This will basically allow test-kitchen to be used as a 'push' service for already-provisioned servers.  (We have some development/test cases where this may be required.)

Sample .kitchen.yml:

```
---
driver:
  name: vagrant

provisioner:
  name: chef_zero
  require_chef_omnibus: false

platforms:
  - name: managed_server
    driver:
      provider: managed
      box: 'managed-server-dummy'
      box_url: 'https://github.com/tknerr/vagrant-managed-servers/raw/master/dummy.box'
      ssh_key: '/path/to/ssh/key'
      username: 'root'
      customize:
        server: '10.0.0.123'

...
```

