### PR TITLE
default communicator to transport

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -44,6 +44,10 @@ module Kitchen
 
       default_config :box_version, nil
 
+      default_config :communicator do |driver|
+        driver.instance.transport.class.name.split('::').last.downcase
+      end
+
       default_config :customize, {}
 
       default_config :gui, nil


### PR DESCRIPTION
This uses the transport value for the communicator if none is specified.

Currently unless the communicator is embedded in the `Vagrantfile` that ships with the vagrant box or a custom erb template is used, users must provide both a `transport` and a `communicator` in the kitchen yaml.

I'm guessing that most do not include communicator config in the Vagrantfile embedded in the box file. `vagrant package` does not include this by default. So without this many users will need to include both a `transport` and a `communicator`.

Of course there may be some implementation I'm missing so if there is something I'm overlooking, please point me in the right direction.