### PR TITLE
Support for WinRM Transport and Windows-based instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,9 +396,10 @@ section of the Vagrant documentation.
 To prevent this value from being rendered in the default Vagrantfile, you can
 set this value to `false`.
 
-The default will be computed from the name of the instance. For
-example, the instance was called "default-fuzz-9" will produce a default
-`vm_hostname` value of `"default-fuzz-9.vagrantup.com"`.
+The default will be computed from the name of the instance. For example, the
+instance was called "default-fuzz-9" will produce a default `vm_hostname` value
+of `"default-fuzz-9"`. For Windows-based platforms, a default of `nil` is used
+to save on boot time and potential rebooting.
 
 ## <a name="development"></a> Development
 

--- a/kitchen-vagrant.gemspec
+++ b/kitchen-vagrant.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "test-kitchen", "~> 1.0"
+  gem.add_dependency "test-kitchen", "= 1.4.0.beta.1"
 
   gem.add_development_dependency "countloc",  "~> 0.4"
   gem.add_development_dependency "rake"

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -29,7 +29,9 @@ module Kitchen
     # Vagrant driver for Kitchen. It communicates to Vagrant via the CLI.
     #
     # @author Fletcher Nichol <fnichol@nichol.ca>
-    class Vagrant < Kitchen::Driver::SSHBase
+    class Vagrant < Kitchen::Driver::Base
+
+      include ShellOut
 
       default_config(:box) { |driver| driver.default_box }
       required_config :box
@@ -46,6 +48,10 @@ module Kitchen
 
       default_config :network, []
 
+      default_config :password do |driver|
+        "vagrant" if driver.winrm_transport?
+      end
+
       default_config :pre_create_command, nil
 
       default_config :provision, false
@@ -58,11 +64,16 @@ module Kitchen
 
       default_config :synced_folders, []
 
+      default_config :username do |driver|
+        "vagrant" if driver.winrm_transport?
+      end
+
       default_config :vagrantfile_erb,
         File.join(File.dirname(__FILE__), "../../../templates/Vagrantfile.erb")
       expand_path_for :vagrantfile_erb
 
       default_config :vagrantfiles, []
+      expand_path_for :vagrantfiles
 
       default_config(:vm_hostname) { |driver| driver.instance.name }
 
@@ -77,6 +88,7 @@ module Kitchen
         run_pre_create_command
         run_vagrant_up
         update_state(state)
+        instance.transport.connection(state).wait_until_ready
         info("Vagrant instance #{instance.to_str} created.")
       end
 
@@ -128,9 +140,7 @@ module Kitchen
       # @raise [ClientError] if instance parameter is nil
       def finalize_config!(instance)
         super
-        config[:vagrantfiles] = config[:vagrantfiles].map do |path|
-          File.expand_path(path, config[:kitchen_root])
-        end
+        finalize_vm_hostname!
         finalize_pre_create_command!
         finalize_synced_folders!
         self
@@ -150,6 +160,13 @@ module Kitchen
             "(#{vagrant_version})." \
             " Please upgrade to version #{MIN_VER} or higher from #{WEBSITE}."
         end
+      end
+
+      # @return [TrueClass,FalseClass] whether or not the transport's name
+      #   implies a WinRM-based transport
+      # @api private
+      def winrm_transport?
+        instance.transport.name.downcase =~ /win_?rm/
       end
 
       protected
@@ -223,6 +240,18 @@ module Kitchen
           end
       end
 
+      # Truncates the length of `:vm_hostname` to 12 characters for
+      # Windows-based operating systems.
+      #
+      # @api private
+      def finalize_vm_hostname!
+        string = config[:vm_hostname]
+
+        if windows_os? && string.is_a?(String) && string.size >= 12
+          config[:vm_hostname] = "#{string[0...10]}-#{string[-1]}"
+        end
+      end
+
       # Renders the Vagrantfile ERb template.
       #
       # @return [String] the contents for a Vagrantfile
@@ -248,6 +277,22 @@ module Kitchen
       def run(cmd, options = {})
         cmd = "echo #{cmd}" if config[:dry_run]
         run_command(cmd, { :cwd => vagrant_root }.merge(options))
+      end
+
+      # Delegates to Kitchen::ShellOut.run_command, overriding some default
+      # options:
+      #
+      # * `:use_sudo` defaults to the value of `config[:use_sudo]` in the
+      #   Driver object
+      # * `:log_subject` defaults to a String representation of the Driver's
+      #   class name
+      #
+      # @see Kitchen::ShellOut#run_command
+      def run_command(cmd, options = {})
+        merged = {
+          :use_sudo => config[:use_sudo], :log_subject => name
+        }.merge(options)
+        super(cmd, merged)
       end
 
       # Runs a local command before `vagrant up` has been called.
@@ -288,10 +333,16 @@ module Kitchen
         hash = vagrant_ssh_config
 
         state[:hostname] = hash["HostName"]
-        state[:username] = hash["User"]
-        state[:ssh_key] = hash["IdentityFile"]
-        state[:port] = hash["Port"]
-        state[:proxy_command] = hash["ProxyCommand"] if hash["ProxyCommand"]
+
+        if winrm_transport?
+          state[:username] = config[:username]
+          state[:password] = config[:password]
+        else
+          state[:username] = hash["User"]
+          state[:ssh_key] = hash["IdentityFile"]
+          state[:port] = hash["Port"]
+          state[:proxy_command] = hash["ProxyCommand"] if hash["ProxyCommand"]
+        end
       end
 
       # @return [String] full local path to the directory containing the

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -75,7 +75,9 @@ module Kitchen
       default_config :vagrantfiles, []
       expand_path_for :vagrantfiles
 
-      default_config(:vm_hostname) { |driver| driver.instance.name }
+      default_config(:vm_hostname) do |driver|
+        driver.windows_os? ? nil : driver.instance.name
+      end
 
       no_parallel_for :create, :destroy
 

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -23,6 +23,7 @@ require "stringio"
 
 require "kitchen/driver/vagrant"
 require "kitchen/provisioner/dummy"
+require "kitchen/transport/dummy"
 
 describe Kitchen::Driver::Vagrant do
 
@@ -33,6 +34,7 @@ describe Kitchen::Driver::Vagrant do
   let(:suite)         { Kitchen::Suite.new(:name => "suitey") }
   let(:busser)        { double("busser") }
   let(:provisioner)   { Kitchen::Provisioner::Dummy.new }
+  let(:transport)     { Kitchen::Transport::Dummy.new }
   let(:state_file)    { double("state_file") }
   let(:state)         { Hash.new }
   let(:env)           { Hash.new }
@@ -53,6 +55,7 @@ describe Kitchen::Driver::Vagrant do
       :suite => suite,
       :platform => platform,
       :provisioner => provisioner,
+      :transport => transport,
       :state_file => state_file
     )
   end
@@ -295,14 +298,60 @@ describe Kitchen::Driver::Vagrant do
       )
     end
 
-    it "sets :vm_hostname to the instance name by default" do
-      expect(driver[:vm_hostname]).to eq("suitey-fooos-99")
+    context "for unix os_types" do
+
+      before { allow(platform).to receive(:os_type).and_return("unix") }
+
+      it "sets :vm_hostname to the instance name by default" do
+        expect(driver[:vm_hostname]).to eq("suitey-fooos-99")
+      end
+
+      it "sets :vm_hostname to a custom value" do
+        config[:vm_hostname] = "okay"
+
+        expect(driver[:vm_hostname]).to eq("okay")
+      end
     end
 
-    it "sets :vm_hostname to a custom value" do
-      config[:vm_hostname] = "okay"
+    context "for windows os_types" do
 
-      expect(driver[:vm_hostname]).to eq("okay")
+      before { allow(platform).to receive(:os_type).and_return("windows") }
+
+      it "sets :vm_hostname to a truncated 12-char instance name by default" do
+        expect(driver[:vm_hostname]).to eq("suitey-foo-9")
+      end
+
+      it "sets :vm_hostname to a custom value, truncated to 12 chars" do
+        config[:vm_hostname] = "this-is-a-pretty-long-name-ya-think"
+
+        expect(driver[:vm_hostname]).to eq("this-is-a--k")
+      end
+    end
+
+    context "for non-WinRM-based transports" do
+
+      before { allow(transport).to receive(:name).and_return("Coolness") }
+
+      it "sets :username to nil by default" do
+        expect(driver[:username]).to eq(nil)
+      end
+
+      it "sets :password to nil by default" do
+        expect(driver[:password]).to eq(nil)
+      end
+    end
+
+    context "for WinRM-based transports" do
+
+      before { allow(transport).to receive(:name).and_return("WinRM") }
+
+      it "sets :username to vagrant by default" do
+        expect(driver[:username]).to eq("vagrant")
+      end
+
+      it "sets :password to vagrant by default" do
+        expect(driver[:password]).to eq("vagrant")
+      end
     end
   end
 
@@ -367,6 +416,14 @@ describe Kitchen::Driver::Vagrant do
       cmd
 
       expect(File.exist?(File.join(vagrant_root, "Vagrantfile"))).to eq(true)
+    end
+
+    it "calls Transport's #wait_until_ready" do
+      conn = double("connection")
+      allow(transport).to receive(:connection).with(state).and_return(conn)
+      expect(conn).to receive(:wait_until_ready)
+
+      cmd
     end
 
     it "logs the Vagrantfile contents on debug level" do
@@ -448,35 +505,59 @@ describe Kitchen::Driver::Vagrant do
         expect(state).to include(:hostname => "192.168.32.64")
       end
 
-      it "sets :username from ssh-config" do
-        cmd
+      context "for non-WinRM-based transports" do
 
-        expect(state).to include(:username => "vagrant")
+        before { allow(transport).to receive(:name).and_return("Coolness") }
+
+        it "sets :username from ssh-config" do
+          cmd
+
+          expect(state).to include(:username => "vagrant")
+        end
+
+        it "sets :ssh_key from ssh-config" do
+          cmd
+
+          expect(state).to include(:ssh_key => "/path/to/private_key")
+        end
+
+        it "sets :port from ssh-config" do
+          cmd
+
+          expect(state).to include(:port => "2022")
+        end
+
+        it "does not set :proxy_command by default" do
+          cmd
+
+          expect(state.keys).to_not include(:proxy_command)
+        end
+
+        it "sets :proxy_command if ProxyCommand is in ssh-config" do
+          output.concat("  ProxyCommand echo proxy\n")
+          cmd
+
+          expect(state).to include(:proxy_command => "echo proxy")
+        end
       end
 
-      it "sets :ssh_key from ssh-config" do
-        cmd
+      context "for WinRM-based transports" do
 
-        expect(state).to include(:ssh_key => "/path/to/private_key")
-      end
+        before { allow(transport).to receive(:name).and_return("WinRM") }
 
-      it "sets :port from ssh-config" do
-        cmd
+        it "sets :username from config" do
+          config[:username] = "winuser"
+          cmd
 
-        expect(state).to include(:port => "2022")
-      end
+          expect(state).to include(:username => "winuser")
+        end
 
-      it "does not set :proxy_command by default" do
-        cmd
+        it "sets :password from config" do
+          config[:password] = "mysecret"
+          cmd
 
-        expect(state.keys).to_not include(:proxy_command)
-      end
-
-      it "sets :proxy_command if ProxyCommand is in ssh-config" do
-        output.concat("  ProxyCommand echo proxy\n")
-        cmd
-
-        expect(state).to include(:proxy_command => "echo proxy")
+          expect(state).to include(:password => "mysecret")
+        end
       end
     end
 

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -317,8 +317,8 @@ describe Kitchen::Driver::Vagrant do
 
       before { allow(platform).to receive(:os_type).and_return("windows") }
 
-      it "sets :vm_hostname to a truncated 12-char instance name by default" do
-        expect(driver[:vm_hostname]).to eq("suitey-foo-9")
+      it "sets :vm_hostname to nil by default" do
+        expect(driver[:vm_hostname]).to eq(nil)
       end
 
       it "sets :vm_hostname to a custom value, truncated to 12 chars" do

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -24,6 +24,7 @@ require "stringio"
 require "kitchen/driver/vagrant"
 require "kitchen/provisioner/dummy"
 require "kitchen/transport/dummy"
+require "kitchen/verifier/dummy"
 
 describe Kitchen::Driver::Vagrant do
 
@@ -32,7 +33,7 @@ describe Kitchen::Driver::Vagrant do
   let(:config)        { { :kitchen_root => "/kroot" } }
   let(:platform)      { Kitchen::Platform.new(:name => "fooos-99") }
   let(:suite)         { Kitchen::Suite.new(:name => "suitey") }
-  let(:busser)        { double("busser") }
+  let(:verifier)      { Kitchen::Verifier::Dummy.new }
   let(:provisioner)   { Kitchen::Provisioner::Dummy.new }
   let(:transport)     { Kitchen::Transport::Dummy.new }
   let(:state_file)    { double("state_file") }
@@ -49,7 +50,7 @@ describe Kitchen::Driver::Vagrant do
 
   let(:instance) do
     Kitchen::Instance.new(
-      :busser => busser,
+      :verifier => verifier,
       :driver => driver_object,
       :logger => logger,
       :suite => suite,


### PR DESCRIPTION
For the moment, we're going to pin to the 1.4.0.beta.1 release of Test Kitchen as any other releases may be incompatible. This will be relaxed for the final release.