### PR TITLE
Use the vagrant-winrm Vagrant plugin to resolve VM IP address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ consider the [vagrant-wrapper][vagrant_wrapper] gem which helps manage both
 styles of Vagrant installations
 ([background details][vagrant_wrapper_background]).
 
+If you are creating Windows VMs over a WinRM Transport, then the
+[vagrant-winrm][vagrant_winrm] Vagrant plugin must be installed. As a
+consequence, the minimum version of Vagrant required is 1.6 or higher.
+
 ### <a name="dependencies-virtualization"></a> Virtualbox and/or VMware Fusion/Workstation
 
 Currently this driver supports VirtualBox and VMware Fusion/Workstation.
@@ -442,6 +446,7 @@ Apache 2.0 (see [LICENSE][license])
 [vagrant_config_vmware]:    http://docs.vagrantup.com/v2/vmware/configuration.html
 [vagrant_providers]:        http://docs.vagrantup.com/v2/providers/index.html
 [vagrant_versioning]:       https://docs.vagrantup.com/v2/boxes/versioning.html
+[vagrant_winrm]:            https://github.com/criteo/vagrant-winrm
 [vagrant_wrapper]:          https://github.com/org-binbab/gem-vagrant-wrapper
 [vagrant_wrapper_background]: https://github.com/org-binbab/gem-vagrant-wrapper#background---aka-the-vagrant-gem-enigma
 [vmware_plugin]:            http://www.vagrantup.com/vmware


### PR DESCRIPTION
It turns out that the IP address of the Vagrant VM returned by the
`vagrant ssh-config` varies with each Vagrant provider and so can't be
relied on to return a private/nat'ed address. In some cases
`"127.0.0.1"` is returned and the locally forward port is returned for
the port number.

To resolve this, the `vagrant-winrm` Vagrant plugin will be used,
exposing a `vagrant winrm-config` subcommand to return WinRM-specific
connection details of the form:

    Host CustomHostname
      HostName Windows2008VM.vagrant.up
      Port 5985
      User vagrant
      Password vagrant

This plugin requires version 1.6 of Vagrant or higher and this Driver
will check to see that the plugin is installed and the Vagrant version
is sufficient--if not a UserError is raised with a message describing
what action(s) to take.

If a WinRM transport is not used, then the minimum version of Vagrant
remains 1.1.0 (as before) and the `vagrant-winrm` plugin will not be
required keeping a slimer set of requirements for users who don't care
to manage Windows VMs.

For more details about the `vagrant-winrm` plugin, please see:

https://github.com/criteo/vagrant-winrm

Closes #153