### PR TITLE
Use RDPPort value from `vagrant winrm-config` for WinRM Transports.

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -357,6 +357,7 @@ module Kitchen
         state[:password] = hash["Password"] if hash["Password"]
         state[:ssh_key] = hash["IdentityFile"] if hash["IdentityFile"]
         state[:proxy_command] = hash["ProxyCommand"] if hash["ProxyCommand"]
+        state[:rdp_port] = hash["RDPPort"] if hash["RDPPort"]
       end
 
       # @return [String] full local path to the directory containing the

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -605,6 +605,7 @@ describe Kitchen::Driver::Vagrant do
               User vagrant
               Password yep
               Port 9999
+              RDPPort 5555
           OUTPUT
         end
 
@@ -636,6 +637,12 @@ describe Kitchen::Driver::Vagrant do
           cmd
 
           expect(state).to include(:password => "yep")
+        end
+
+        it "sets :rdp_port from winrm-config" do
+          cmd
+
+          expect(state).to include(:rdp_port => "5555")
         end
       end
     end


### PR DESCRIPTION
Much <3 and thanks to @Annih for an epic turnaround. This is what makes
open source so rewarding.