### PR TITLE
Close Transport connection in #destroy.

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -117,6 +117,7 @@ module Kitchen
 
         create_vagrantfile
         @vagrantfile_created = false
+        instance.transport.connection(state).close
         run("vagrant destroy -f")
         FileUtils.rm_rf(vagrant_root)
         info("Vagrant instance #{instance.to_str} destroyed.")

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -710,6 +710,14 @@ describe Kitchen::Driver::Vagrant do
       cmd
     end
 
+    it "closes the transport connection" do
+      connection = double(Kitchen::Transport::Base::Connection)
+      allow(transport).to receive(:connection).with(state) { connection }
+      expect(connection).to receive(:close)
+
+      cmd
+    end
+
     it "runs vagrant destroy" do
       expect(driver).to receive(:run_command).
         with("vagrant destroy -f", any_args)


### PR DESCRIPTION
This allows a `kitchen test` run to cleanly close any connection
resources on the remote instance before the instance is destroyed.