### PR TITLE
point out where to find plugin documentation for ChefDK 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A Test Kitchen Driver for Vagrant.
 
-**Documentation for v0.15.0, which is included in ChefDK v1.3.1 can be
+**Documentation for v0.15.0, which is included in test kitchen v1.3.1 can be
 found
 [here](https://github.com/test-kitchen/kitchen-vagrant/tree/v0.15.0)**
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 A Test Kitchen Driver for Vagrant.
 
+**Documentation for v0.15.0, which is included in ChefDK v1.3.1 can be
+found
+[here](https://github.com/test-kitchen/kitchen-vagrant/tree/v0.15.0)**
+
 This driver works by generating a single Vagrantfile for each instance in a
 sandboxed directory. Since the Vagrantfile is written out on disk, Vagrant
 needs absolutely no knowledge of Test Kitchen. So no Vagrant plugins are


### PR DESCRIPTION
When looking using this plugin (in ChefDK version 1.3.1) I spent hours wondering why the supported options in the master branch weren't respected by the kitchen-vagrant version I was using in ChefDK.

This PR makes it plain where the user needs to go to find the correct version of the kitchen-vagrant driver.