### PR TITLE
add handling for winrm communicator in username & password handling

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -935,6 +935,22 @@ describe Kitchen::Driver::Vagrant do
       expect(vagrantfile).to match(regexify(%{c.ssh.password = "okay"}))
     end
 
+    it "sets communicator.username if :communicator and :username are set" do
+      config[:communicator] = "wat"
+      config[:username] = "jdoe"
+      cmd
+
+      expect(vagrantfile).to match(regexify(%{c.wat.username = "jdoe"}))
+    end 
+
+    it "sets communicator.password if :communicator and :password are set" do
+      config[:communicator] = "wat"
+      config[:password] = "okay"
+      cmd
+
+      expect(vagrantfile).to match(regexify(%{c.wat.password = "okay"}))
+    end 
+
     it "sets no ssh.private_key_path if missing" do
       config[:ssh_key] = nil
       cmd

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -941,7 +941,7 @@ describe Kitchen::Driver::Vagrant do
       cmd
 
       expect(vagrantfile).to match(regexify(%{c.wat.username = "jdoe"}))
-    end 
+    end
 
     it "sets communicator.password if :communicator and :password are set" do
       config[:communicator] = "wat"
@@ -949,7 +949,7 @@ describe Kitchen::Driver::Vagrant do
       cmd
 
       expect(vagrantfile).to match(regexify(%{c.wat.password = "okay"}))
-    end 
+    end
 
     it "sets no ssh.private_key_path if missing" do
       config[:ssh_key] = nil

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -30,14 +30,12 @@ Vagrant.configure("2") do |c|
   c.vm.guest = "<%= config[:guest] %>"
 <% end %>
 
-
-
-<% if config[:communicator] == "winrm" %>
+<% if config[:communicator] %>
   <% if config[:username] %>
-    c.winrm.username = "<%= config[:username] %>"
+    c.<%= config[:communicator] %>.username = "<%= config[:username] %>"
   <% end %>
   <% if config[:password] %>
-    c.winrm.password = "<%= config[:password] %>"
+    c.<%= config[:communicator] %>.password = "<%= config[:password] %>"
   <% end %>
 <% else %>
   <% if config[:username] %>
@@ -47,8 +45,6 @@ Vagrant.configure("2") do |c|
     c.ssh.password = "<%= config[:password] %>"
   <% end %>
 <% end %>
-
-
 
 <% if config[:ssh_key] %>
   c.ssh.private_key_path = "<%= config[:ssh_key] %>"

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -30,12 +30,26 @@ Vagrant.configure("2") do |c|
   c.vm.guest = "<%= config[:guest] %>"
 <% end %>
 
-<% if config[:username] %>
-  c.<%= config[:communicator] %>.username = "<%= config[:username] %>"
+
+
+<% if config[:communicator] == "winrm" %>
+  <% if config[:username] %>
+    c.winrm.username = "<%= config[:username] %>"
+  <% end %>
+  <% if config[:password] %>
+    c.winrm.password = "<%= config[:password] %>"
+  <% end %>
+<% else %>
+  <% if config[:username] %>
+    c.ssh.username = "<%= config[:username] %>"
+  <% end %>
+  <% if config[:password] %>
+    c.ssh.password = "<%= config[:password] %>"
+  <% end %>
 <% end %>
-<% if config[:password] %>
-  c.<%= config[:communicator] %>.password = "<%= config[:password] %>"
-<% end %>
+
+
+
 <% if config[:ssh_key] %>
   c.ssh.private_key_path = "<%= config[:ssh_key] %>"
 <% end %>

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -31,16 +31,21 @@ Vagrant.configure("2") do |c|
 <% end %>
 
 <% if config[:username] %>
-  c.ssh.username = "<%= config[:username] %>"
+  c.<%= config[:communicator] %>.username = "<%= config[:username] %>"
 <% end %>
 <% if config[:password] %>
-  c.ssh.password = "<%= config[:password] %>"
+  c.<%= config[:communicator] %>.password = "<%= config[:password] %>"
 <% end %>
 <% if config[:ssh_key] %>
   c.ssh.private_key_path = "<%= config[:ssh_key] %>"
 <% end %>
 <% config[:ssh].each do |key, value| %>
   c.ssh.<%= key %> = <%= value %>
+<% end %>
+<% if config[:winrm] %>
+  <% config[:winrm].each do |key, value| %>
+    c.winrm.<%= key %> = <%= value %>
+  <% end %>
 <% end %>
 
 <% Array(config[:network]).each do |opts| %>


### PR DESCRIPTION
this fixes winrm out of the box. before change c.vm.communicator would be set to winrm correctly but username and password would be prefixed with c.ssh. also add handling for additional winrm config settings 