### PR TITLE
Update CentOS 7.0 to 7.1

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -193,7 +193,7 @@ module Kitchen
       # @api private
       def bento_boxes
         %W[
-          centos-5.11 centos-6.6 centos-7.0 debian-6.0.10 debian-7.8 fedora-20
+          centos-5.11 centos-6.6 centos-7.1 debian-6.0.10 debian-7.8 fedora-20
           fedora-21 freebsd-9.3 freebsd-10.1 opensuse-13.1 ubuntu-10.04
           ubuntu-12.04 ubuntu-14.04 ubuntu-14.10
         ].map { |name| [name, "#{name}-i386"] }.flatten


### PR DESCRIPTION
Tiny change. A 7.1 Bento box was added and the 7.0 one retired [recently](https://github.com/chef/bento/commits/master).

Although... the 7.0 box does still exist in S3, so... would it be better to just leave them both?

Thanks!