### PR TITLE
Fix config[:ssh] to be quoted properly

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -953,9 +953,9 @@ describe Kitchen::Driver::Vagrant do
 
     it "adds a vm.ssh line for each key/value pair in :ssh" do
       config[:ssh] = {
-        :username => %{"jdoe"},
-        :password => %{"secret"},
-        :private_key_path => %{"/key"}
+        :username => %{jdoe},
+        :password => %{secret},
+        :private_key_path => %{/key}
       }
       cmd
 

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -40,7 +40,7 @@ Vagrant.configure("2") do |c|
   c.ssh.private_key_path = "<%= config[:ssh_key] %>"
 <% end %>
 <% config[:ssh].each do |key, value| %>
-  c.ssh.<%= key %> = <%= value %>
+  c.ssh.<%= key %> = "<%= value %>"
 <% end %>
 
 <% Array(config[:network]).each do |opts| %>


### PR DESCRIPTION
With the this small fix, the following example will work as expected:

```yaml
driver:
  ssh:
    shell: 'sh'
```

Related to: #131, bf38f9492798b995befc70723166ede8f3b3c96e