### PR TITLE
Allow a fuzzier match for known Bento box names.

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -93,7 +93,7 @@ module Kitchen
 
       # @return [String,nil] the Vagrant box for this Instance
       def default_box
-        if bento_boxes.include?(instance.platform.name)
+        if bento_box?(instance.platform.name)
           "opscode-#{instance.platform.name}"
         else
           instance.platform.name
@@ -102,7 +102,7 @@ module Kitchen
 
       # @return [String,nil] the Vagrant box URL for this Instance
       def default_box_url
-        return unless bento_boxes.include?(instance.platform.name)
+        return unless bento_box?(instance.platform.name)
 
         provider = config[:provider]
         provider = "vmware" if config[:provider] =~ /^vmware_(.+)$/
@@ -186,17 +186,15 @@ module Kitchen
         attr_accessor :vagrant_version
       end
 
-      # Retuns a list of Vagrant base boxes produced by the Bento project
+      # Retuns whether or not a platform name could have a correcponding Bento
+      # box produced by the Bento project.
       # (https://github.com/chef/bento).
       #
-      # @return [Arrau<String>] list of Bento box names
+      # @return [TrueClass,FalseClass] whether or not the name could be a Bento
+      #   box
       # @api private
-      def bento_boxes
-        %W[
-          centos-5.11 centos-6.6 centos-7.0 debian-6.0.10 debian-7.8 fedora-20
-          fedora-21 freebsd-9.3 freebsd-10.1 opensuse-13.1 ubuntu-10.04
-          ubuntu-12.04 ubuntu-14.04 ubuntu-14.10
-        ].map { |name| [name, "#{name}-i386"] }.flatten
+      def bento_box?(name)
+        name =~ /^(centos|debian|fedora|freebsd|opensuse|ubuntu)-/
       end
 
       # Renders and writes out a Vagrantfile dedicated to this instance.

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -79,42 +79,45 @@ describe Kitchen::Driver::Vagrant do
 
   describe "configuration" do
 
-    context "for known bento platform names" do
+    %W[centos debian fedora opensuse ubuntu].each do |name|
 
-      before { allow(platform).to receive(:name) { "ubuntu-14.04" } }
+      context "for known bento platform names starting with #{name}" do
 
-      it "sets :box based on the platform name by default" do
-        expect(driver[:box]).to eq("opscode-ubuntu-14.04")
-      end
+        before { allow(platform).to receive(:name) { "#{name}-99.04" } }
 
-      it "sets :box to a custom value" do
-        config[:box] = "booya"
+        it "sets :box based on the platform name by default" do
+          expect(driver[:box]).to eq("opscode-#{name}-99.04")
+        end
 
-        expect(driver[:box]).to eq("booya")
-      end
+        it "sets :box to a custom value" do
+          config[:box] = "booya"
 
-      it "sets :box_url to a bento box URL for a virtualbox provider" do
-        config[:provider] = "virtualbox"
+          expect(driver[:box]).to eq("booya")
+        end
 
-        expect(driver[:box_url]).to eq(
-          "https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/" \
-          "opscode_ubuntu-14.04_chef-provisionerless.box"
-        )
-      end
+        it "sets :box_url to a bento box URL for a virtualbox provider" do
+          config[:provider] = "virtualbox"
 
-      it "sets :box_url to a bento box URL for a vmware-based provider" do
-        config[:provider] = "vmware_awesometown"
+          expect(driver[:box_url]).to eq(
+            "https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/" \
+            "opscode_#{name}-99.04_chef-provisionerless.box"
+          )
+        end
 
-        expect(driver[:box_url]).to eq(
-          "https://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/" \
-          "opscode_ubuntu-14.04_chef-provisionerless.box"
-        )
-      end
+        it "sets :box_url to a bento box URL for a vmware-based provider" do
+          config[:provider] = "vmware_awesometown"
 
-      it "sets :box_url to nil for any other provider" do
-        config[:provider] = "the-next-coolness"
+          expect(driver[:box_url]).to eq(
+            "https://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/" \
+            "opscode_#{name}-99.04_chef-provisionerless.box"
+          )
+        end
 
-        expect(driver[:box_url]).to eq(nil)
+        it "sets :box_url to nil for any other provider" do
+          config[:provider] = "the-next-coolness"
+
+          expect(driver[:box_url]).to eq(nil)
+        end
       end
     end
 


### PR DESCRIPTION
This update attempts to improve on
a2ef401fb5a644c96165ce836ff3e6379637a37f which remains a workaround
until the work of continuously publishing Bento boxes to Atlas is
completed.

The rationale and rules in the above mentioned commit remain, but now
only the platform name is checked. In other words, if the platform name
begins with one of the following (case-sensitive):

* `centos`
* `debian`
* `fedora`
* `freebsd`
* `opensuse`
* `ubuntu`

then the platform is assumed to have a Bento box, hosted in the
pre-determined S3 bucket.

References #165
References test-kitchen/test-kitchen#707
References test-kitchen/test-kitchen#663
References chef/chef-dk#382
References chef/chef-dk#378