### PR TITLE
Customize supports other vagrant providers, fixes #171

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1365,6 +1365,28 @@ describe Kitchen::Driver::Vagrant do
         RUBY
       end
     end
+
+    context "for openstack provider" do
+
+      before { config[:provider] = "openstack" }
+
+      it "adds a line for each element in :customize" do
+        config[:customize] = {
+          :key1 => "some string value",
+          :key2 => 22,
+          :key3 => false
+        }
+        cmd
+
+        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+          c.vm.provider :openstack do |p|
+            p.key1 = "some string value"
+            p.key2 = 22
+            p.key3 = false
+          end
+        RUBY
+        end
+    end
   end
 
   def debug_lines

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1385,7 +1385,7 @@ describe Kitchen::Driver::Vagrant do
             p.key3 = false
           end
         RUBY
-        end
+      end
     end
   end
 

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -118,6 +118,8 @@ Vagrant.configure("2") do |c|
     <% else %>
     p.vmx["<%= key %>"] = "<%= value %>"
     <% end %>
+  <% else %>
+    p.<%= key %> = "<%= value%>"
   <% end %>
 <% end %>
   end

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -118,8 +118,12 @@ Vagrant.configure("2") do |c|
     <% else %>
     p.vmx["<%= key %>"] = "<%= value %>"
     <% end %>
-  <% else %>
+  <% else # other vagrant provider %>
+    <% if value.is_a? String %>
     p.<%= key %> = "<%= value%>"
+    <% else  %>
+    p.<%= key %> = <%= value%>
+    <% end  %>
   <% end %>
 <% end %>
   end

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -118,7 +118,7 @@ Vagrant.configure("2") do |c|
     <% else %>
     p.vmx["<%= key %>"] = "<%= value %>"
     <% end %>
-  <% else # other vagrant provider %>
+  <% when "openstack" %>
     <% if value.is_a? String %>
     p.<%= key %> = "<%= value%>"
     <% else  %>


### PR DESCRIPTION
Fixes #171 

Updated Vagrantfile template so that now "customize" option has a default behavior for Vagrant providers which are not case listed.