### PR TITLE
Support `createhd`, `storageattach` option for Virtualbox

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -105,7 +105,21 @@ Vagrant.configure("2") do |c|
     p.<%= key %> = "<%= value %>"
     <% end %>
   <% when "virtualbox" %>
+    <% if key == :createhd %>
+    p.customize ["createhd", "--filename", "<%= value[:filename] %>", "--size", <%= value[:size] %>]
+    <% elsif key == :storageattach %>
+      <% options = [] %>
+      <% value.each do |storageattach_option_key, storageattach_option_value|
+           if storageattach_option_value.instance_of? Fixnum
+             options << "'--#{storageattach_option_key}', #{storageattach_option_value}"
+           else
+             options << "'--#{storageattach_option_key}', '#{storageattach_option_value}'"
+           end
+         end %>
+    p.customize ["storageattach", :id, <%= options.join(',') %> ]
+    <% else %>
     p.customize ["modifyvm", :id, "--<%= key %>", "<%= value %>"]
+    <% end %>
   <% when /^vmware_/ %>
     <% if key == :memory %>
       <% unless config[:customize].include?(:memsize) %>


### PR DESCRIPTION
Update Vagrantfile template.

support Virtualbox options `createhd` and `storageattach`
- https://www.virtualbox.org/manual/ch08.html#vboxmanage-createvdi
- https://www.virtualbox.org/manual/ch08.html#vboxmanage-storageattach

like this

``` markdown
platforms:
  - name: ubuntu-14.04
    driver:
      box: trusty64
      customize:
        memory: 1024
        cpus: 4
        nictype1: virtio
        createhd:
          filename: ./tmp/diskfile1.vmdk
          size: 100 * 1024
        storageattach:
          storagectl: IDE Controller
          port: 1
          device: 0
          type: hdd
          medium: ./tmp/diskfile1.vmdk
```
