### PR TITLE
Fix quoting for cloud providers

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -96,8 +96,6 @@ Vagrant.configure("2") do |c|
     <% end %>
   <% when "parallels" %>
     p.customize ["set", :id, "--<%= key.to_s.gsub('_', '-') %>", "<%= value %>"]
-  <% when "rackspace" %>
-    p.<%= key %> = "<%= value%>"
   <% when "softlayer" %>
     <% if key == :disk_capacity %>
     p.<%= key %> = <%= value %>
@@ -118,7 +116,7 @@ Vagrant.configure("2") do |c|
     <% else %>
     p.vmx["<%= key %>"] = "<%= value %>"
     <% end %>
-  <% when "openstack" %>
+  <% when "openstack", "rackspace", "aws" %>
     <% if value.is_a? String %>
     p.<%= key %> = "<%= value%>"
     <% else  %>


### PR DESCRIPTION
Avoid quoting anything else rather than strings for openstack, aws and rackspace.
Add support for aws provider
