### PR TITLE
Add vagrant-wrapper dependency

### DIFF
--- a/kitchen-vagrant.gemspec
+++ b/kitchen-vagrant.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "test-kitchen", "~> 1.4"
+  gem.add_dependency "vagrant-wrapper"
 
   gem.add_development_dependency "countloc",  "~> 0.4"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
Many users have the vagrant gem installed for development purposes. The vagrant-wrapper gem prevents the conflict of native vagrant with the vagrant gem. Since kitchen-vagrant relies on native vagrant, it would be nice to have this simple dependency to avoid adding it on all of our Gemfiles.