### PR TITLE
Parallels: Use "memory" and "cpus" customization shortcuts

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1078,6 +1078,21 @@ describe Kitchen::Driver::Vagrant do
           end
         RUBY
       end
+
+      it "adds a short form of :memory and :cpus elements in :customize" do
+        config[:customize] = {
+          :memory => 2048,
+          :cpus => 4
+        }
+        cmd
+
+        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+          c.vm.provider :parallels do |p|
+            p.memory = 2048
+            p.cpus = 4
+          end
+        RUBY
+      end
     end
 
     context "for rackspace provider" do

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -95,7 +95,11 @@ Vagrant.configure("2") do |c|
     p.server = "<%= value %>"
     <% end %>
   <% when "parallels" %>
+    <% if key == :memory || key == :cpus %>
+    p.<%= key %> = <%= value %>
+    <% else %>
     p.customize ["set", :id, "--<%= key.to_s.gsub('_', '-') %>", "<%= value %>"]
+    <% end %>
   <% when "rackspace" %>
     p.<%= key %> = "<%= value%>"
   <% when "softlayer" %>


### PR DESCRIPTION
`memory` and `cpus` customization parameters are widely used in `.kitchen.yml` of different community cookbooks.
But currently it doesn't work for "parallels" provider, because `prlctl set` command doesn't support "memory" argument (it expects to get a "memsize" instead).

However, this provider actually supports  `memory` and `cpus` as customization shortcuts (it was implemented for similarity with virtualbox provider):
```ruby
config.vm.provider "parallels" do |prl|
  prl.memory = 1024
  prl.cpus = 2
end
```

So, this PR makes it possible to use `memory` and `cpus` for "parallels" provider.

cc: @fnichol 