### PR TITLE
Use Bento's Atlas boxes by default if detected

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -94,7 +94,7 @@ module Kitchen
       # @return [String,nil] the Vagrant box for this Instance
       def default_box
         if bento_box?(instance.platform.name)
-          "opscode-#{instance.platform.name}"
+          "bento/#{instance.platform.name}"
         else
           instance.platform.name
         end
@@ -102,15 +102,7 @@ module Kitchen
 
       # @return [String,nil] the Vagrant box URL for this Instance
       def default_box_url
-        return unless bento_box?(instance.platform.name)
-
-        provider = config[:provider]
-        provider = "vmware" if config[:provider] =~ /^vmware_(.+)$/
-
-        if %w[virtualbox vmware].include?(provider)
-          "https://opscode-vm-bento.s3.amazonaws.com/vagrant/#{provider}/" \
-            "opscode_#{instance.platform.name}_chef-provisionerless.box"
-        end
+        nil
       end
 
       # Destroys an instance.

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -154,7 +154,7 @@ describe Kitchen::Driver::Vagrant do
         before { allow(platform).to receive(:name) { "#{name}-99.04" } }
 
         it "sets :box based on the platform name by default" do
-          expect(driver[:box]).to eq("opscode-#{name}-99.04")
+          expect(driver[:box]).to eq("bento/#{name}-99.04")
         end
 
         it "sets :box to a custom value" do
@@ -163,25 +163,7 @@ describe Kitchen::Driver::Vagrant do
           expect(driver[:box]).to eq("booya")
         end
 
-        it "sets :box_url to a bento box URL for a virtualbox provider" do
-          config[:provider] = "virtualbox"
-
-          expect(driver[:box_url]).to eq(
-            "https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/" \
-            "opscode_#{name}-99.04_chef-provisionerless.box"
-          )
-        end
-
-        it "sets :box_url to a bento box URL for a vmware-based provider" do
-          config[:provider] = "vmware_awesometown"
-
-          expect(driver[:box_url]).to eq(
-            "https://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/" \
-            "opscode_#{name}-99.04_chef-provisionerless.box"
-          )
-        end
-
-        it "sets :box_url to nil for any other provider" do
+        it "sets :box_url to nil" do
           config[:provider] = "the-next-coolness"
 
           expect(driver[:box_url]).to eq(nil)


### PR DESCRIPTION
Bento hosts its base boxes on https://atlas.hashicorp.com/bento

I'm unsure whether it's worth removing default_box_url, but from a class-api BC, keeping this in will still allow for monkey-patching new behaviours in.

Fixes #193