### PR TITLE
Add vagrant-cachier support to default Vagrantfile.erb

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -6,6 +6,8 @@ Vagrant.configure("2") do |c|
   c.berkshelf.enabled = false if Vagrant.has_plugin?("vagrant-berkshelf")
   c.vm.box = "<%= config[:box] %>"
 
+  c.cache.scope = :box if Vagrant.has_plugin?("vagrant-cachier")
+
 <% if config[:box_url] %>
   c.vm.box_url = "<%= config[:box_url] %>"
 <% end %>


### PR DESCRIPTION
Hey Guys! I believe `vagrant-cachier` is one of the basic vagrant plugins, that is used by majority of engineers in order to save a lot of time during their testing tasks. It would be very nice to not create custom Vagrantfile.erb template for every project =)

(admin edit for waffle linking)
Closes #186
