### PR TITLE
Add linked_clone config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,30 @@ end
 
 For more info about GUI vs. Headless mode please see [vagrant configuration docs][vagrant_config_vbox]
 
+### <a name="config-linked_clone"></a> linked_clone
+
+Allows to use linked clones to import boxes for VirtualBox and VMware. Default is **nil**.
+
+```yaml
+---
+platforms:
+  - name: ubuntu-14.04
+    driver:
+      linked_clone: true
+```
+
+will generate a Vagrantfile configuration similar to:
+
+```ruby
+Vagrant.configure("2") do |config|
+  # ...
+
+  c.vm.provider :virtualbox do |p|
+    p.linked_clone = true
+  end
+end
+```
+
 ### <a name="config-network"></a> network
 
 An **Array** of network customizations for the virtual machine. Each Array

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -53,6 +53,8 @@ module Kitchen
 
       default_config :gui, nil
 
+      default_config :linked_clone, nil
+
       default_config :network, []
 
       default_config :pre_create_command, nil

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -234,6 +234,10 @@ describe Kitchen::Driver::Vagrant do
       expect(driver[:gui]).to eq(nil)
     end
 
+    it "sets :linked_clone to nil by default" do
+      expect(driver[:linked_clone]).to eq(nil)
+    end
+
     it "sets :network to an empty array by default" do
       expect(driver[:network]).to eq([])
     end
@@ -1140,6 +1144,36 @@ describe Kitchen::Driver::Vagrant do
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
             p.gui = true
+          end
+        RUBY
+      end
+
+      it "does not set :linked_clone to nil" do
+        config[:linked_clone] = nil
+        cmd
+
+        expect(vagrantfile).to_not match(
+            regexify(%{p.linked_clone = }, :partial))
+      end
+
+      it "sets :linked_clone to false if set" do
+        config[:linked_clone] = false
+        cmd
+
+        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+          c.vm.provider :virtualbox do |p|
+            p.linked_clone = false
+          end
+        RUBY
+      end
+
+      it "sets :linked_clone to true if set" do
+        config[:linked_clone] = true
+        cmd
+
+        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+          c.vm.provider :virtualbox do |p|
+            p.linked_clone = true
           end
         RUBY
       end

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -77,6 +77,9 @@ Vagrant.configure("2") do |c|
      if config[:gui] == true || config[:gui] == false %>
     p.gui = <%= config[:gui] %>
 <%   end
+     if config[:linked_clone] == true || config[:linked_clone] == false %>
+    p.linked_clone = <%= config[:linked_clone] %>
+<%   end
    end %>
 <% config[:customize].each do |key, value| %>
   <% case config[:provider]


### PR DESCRIPTION
Allows to use linked clones with Vagrant 1.8