### PR TITLE
Ruby 1.9.3 is no longer supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.2
   - 2.1
   - 2.0.0
-  - 1.9.3
   - ruby-head
 
 bundler_args: --without guard


### PR DESCRIPTION
Ruby 1.9.3 is no longer supported, and the tests fail if you try and use it.