### PR TITLE
Swap basename(kitchen_root) with a CRC32 of the whole path

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -393,7 +393,9 @@ module Kitchen
       def vagrant_root
         @vagrant_root ||= instance.nil? ? nil : File.join(
           config[:kitchen_root], %w[.kitchen kitchen-vagrant],
-          "kitchen-#{Zlib.crc32(config[:kitchen_root]).to_s(36).upcase.rjust(8, '0')}-#{instance.name}"
+          "kitchen-"\
+          "#{Zlib.crc32(config[:kitchen_root]).to_s(36).upcase.rjust(8, "0")}-"\
+          "#{instance.name}"
         )
       end
 

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "zlib"
+
 require "erb"
 require "fileutils"
 require "rubygems/version"
@@ -391,7 +393,7 @@ module Kitchen
       def vagrant_root
         @vagrant_root ||= instance.nil? ? nil : File.join(
           config[:kitchen_root], %w[.kitchen kitchen-vagrant],
-          "kitchen-#{File.basename(config[:kitchen_root])}-#{instance.name}"
+          "kitchen-#{Zlib.crc32(config[:kitchen_root]).to_s(36).upcase.rjust(8, '0')}-#{instance.name}"
         )
       end
 

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -517,7 +517,8 @@ describe Kitchen::Driver::Vagrant do
     let(:vagrant_root) do
       File.join(%W[
         #{@dir} .kitchen kitchen-vagrant
-        kitchen-#{Zlib.crc32(@dir).to_s(36).upcase.rjust(8, '0')}-suitey-fooos-99
+        kitchen-#{Zlib.crc32(@dir).to_s(36).upcase.
+            rjust(8, "0")}-suitey-fooos-99
       ])
     end
 
@@ -749,7 +750,8 @@ describe Kitchen::Driver::Vagrant do
     let(:vagrant_root) do
       File.join(%W[
         #{@dir} .kitchen kitchen-vagrant
-        kitchen-#{Zlib.crc32(@dir).to_s(36).upcase.rjust(8, '0')}-suitey-fooos-99
+        kitchen-#{Zlib.crc32(@dir).to_s(36).upcase.
+            rjust(8, "0")}-suitey-fooos-99
       ])
     end
 
@@ -839,7 +841,8 @@ describe Kitchen::Driver::Vagrant do
     let(:vagrant_root) do
       File.join(%W[
         #{@dir} .kitchen kitchen-vagrant
-        kitchen-#{Zlib.crc32(@dir).to_s(36).upcase.rjust(8, '0')}-suitey-fooos-99
+        kitchen-#{Zlib.crc32(@dir).to_s(36).upcase.
+            rjust(8, "0")}-suitey-fooos-99
       ])
     end
 

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -18,6 +18,8 @@
 
 require_relative "../../spec_helper"
 
+require "zlib"
+
 require "logger"
 require "stringio"
 
@@ -515,7 +517,7 @@ describe Kitchen::Driver::Vagrant do
     let(:vagrant_root) do
       File.join(%W[
         #{@dir} .kitchen kitchen-vagrant
-        kitchen-#{File.basename(@dir)}-suitey-fooos-99
+        kitchen-#{Zlib.crc32(@dir).to_s(36).upcase.rjust(8, '0')}-suitey-fooos-99
       ])
     end
 
@@ -747,7 +749,7 @@ describe Kitchen::Driver::Vagrant do
     let(:vagrant_root) do
       File.join(%W[
         #{@dir} .kitchen kitchen-vagrant
-        kitchen-#{File.basename(@dir)}-suitey-fooos-99
+        kitchen-#{Zlib.crc32(@dir).to_s(36).upcase.rjust(8, '0')}-suitey-fooos-99
       ])
     end
 
@@ -837,7 +839,7 @@ describe Kitchen::Driver::Vagrant do
     let(:vagrant_root) do
       File.join(%W[
         #{@dir} .kitchen kitchen-vagrant
-        kitchen-#{File.basename(@dir)}-suitey-fooos-99
+        kitchen-#{Zlib.crc32(@dir).to_s(36).upcase.rjust(8, '0')}-suitey-fooos-99
       ])
     end
 

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -272,7 +272,7 @@ describe Kitchen::Driver::Vagrant do
       config[:pre_create_command] = "{{vagrant_root}}/candy"
 
       expect(driver[:pre_create_command]).to eq(
-        "/kroot/.kitchen/kitchen-vagrant/kitchen-kroot-suitey-fooos-99/candy"
+        "/kroot/.kitchen/kitchen-vagrant/kitchen-017YDE1N-suitey-fooos-99/candy"
       )
     end
 


### PR DESCRIPTION
Proposed solution for the issue #210

The prefix turns out to be "kitchen-XXXXXXXX", where XXXXXXXX is the CRC32 in base 36 of the complete kitchen_root, always 8 characters wide.

Fixes #210
