### PR TITLE
Add support for hyperv customize

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -140,6 +140,12 @@ Vagrant.configure("2") do |c|
     <% else  %>
     p.<%= key %> = <%= value%>
     <% end  %>
+  <% when "hyperv" %>
+    <% if value.is_a? String %>
+    p.<%= key %> = "<%= value%>"
+    <% else  %>
+    p.<%= key %> = <%= value%>
+    <% end  %>
   <% end %>
 <% end %>
   end


### PR DESCRIPTION
I've found hyperv customize code in my .kitchen.yml not applied. So I manually modified template/Vagrantfile.erb and now it works.

Testing environment:
- Windows 10 64-bit (build 10586 / version 1511) with Hyper-V platform enabled
- ChefDK 0.10.0
- Vagrant 1.8.1
- Kitchen 1.4.2
