### PR TITLE
Allow multiple "include" statements in LXC configuration

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -107,6 +107,10 @@ Vagrant.configure("2") do |c|
       <% config[:customize][:backingstore_options].each do |opt, opt_val| %>
     p.backingstore_option "--<%= opt %>", "<%= opt_val %>"
       <% end %>
+    <% elsif key == :include %>
+      <% Array(value).each do |include| %>
+    p.customize "<%= key %>", "<%= include %>"
+      <% end %>
     <% else %>
     p.customize "<%= key %>", "<%= value %>"
     <% end %>


### PR DESCRIPTION
LXC configuration allows for including files with common settings (see
`lxc.container.conf(5)`).  This is `lxc.include` directive differs
from other settings, in that multiple settings of the same key makes
sense.  Previously, a configuration of the form:

```
driver:
  name: vagrant
  provider: lxc
  customize:
    include: '/usr/share/lxc/config/ubuntu.common.conf'
    include: '/usr/share/lxc/config/nesting.conf'
```

...would necessarily only include one of the files, as duplicate keys
are collapsed during YAML loading.  Since the existing code assumes
that all values are scalar, it was likewise impossible to set
`include` to an array.

Extend the supported syntax to allow:

```
driver:
  name: vagrant
  provider: lxc
  customize:
    include:
     - '/usr/share/lxc/config/ubuntu.common.conf'
     - '/usr/share/lxc/config/nesting.conf'
```

...which produces an LXC configuration of:

```
lxc.include=/usr/share/lxc/config/ubuntu.common.conf
lxc.include=/usr/share/lxc/config/nesting.conf
```
