### PR TITLE
Fix ssh boolean values in Vagrantfile template

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1111,7 +1111,8 @@ describe Kitchen::Driver::Vagrant do
       config[:ssh] = {
         :username => %{jdoe},
         :password => %{secret},
-        :private_key_path => %{/key}
+        :private_key_path => %{/key},
+        :insert_key => false
       }
       cmd
 
@@ -1119,6 +1120,7 @@ describe Kitchen::Driver::Vagrant do
         c.ssh.username = "jdoe"
         c.ssh.password = "secret"
         c.ssh.private_key_path = "/key"
+        c.ssh.insert_key = false
       RUBY
     end
 

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -54,7 +54,7 @@ Vagrant.configure("2") do |c|
   c.ssh.private_key_path = "<%= config[:ssh_key] %>"
 <% end %>
 <% config[:ssh].each do |key, value| %>
-  c.ssh.<%= key %> = "<%= value %>"
+  c.ssh.<%= key %> = <%= value.inspect %>
 <% end %>
 <% if config[:winrm] %>
   <% config[:winrm].each do |key, value| %>


### PR DESCRIPTION
This PR fixes boolean values inside the `ssh:` configuration key. For example:

```yaml
---
driver:
  ssh:
    insert_key: false
```

This will create a Vagrantfile like the following:

```ruby
Vagrant.configure("2") do |c|
  c.ssh.insert_key = "false"
end
```

Instead of:

```ruby
Vagrant.configure("2") do |c|
  c.ssh.insert_key = false
end
```

This PR fixes that little problem.

Bug mentioned in #163.