### PR TITLE
Fix the name of "Parallels Desktop for Mac"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ software from VMware and then must also purchase the Vagrant VMware plugin.
 
 [VMware Workstation][workstation_dl]
 
-If you would like to use Parallels you must also purchase the software but the
+If you would like to use Parallels Desktop you must also purchase the software but the
 `vagrant-parallels` plugin is freely available.
 
-[Parllels][parallels_dl]
+[Parallels Desktop for Mac][parallels_dl]
 
 [Vagrant Parallels Provider][vagrant_parallels]
 


### PR DESCRIPTION
There is a typo in README: "Parllels". 
Also I would recommend using the correct product name, which is "Parallels Desktop for Mac" (shortly - "Parallels Desktop").