### PR TITLE
Configure box_download_ca_cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The default will be computed from the platform name of the instance. However, fo
 
 For example, a platform with a Bento box called "ubuntu-14.04" will produce a
 default `box` value of `"opscode-ubuntu-14.04"`. Alternatively, a box called
-`"slackware-14.1"` will produce a default `box` value of `"slackware-14.1".
+`"slackware-14.1"` will produce a default `box` value of `"slackware-14.1"`.
 
 ### <a name="config-box-check-update"></a> box\_check\_update
 
@@ -158,6 +158,22 @@ A default URL will be computed only for a small number of common/known
 platforms in the [Bento][bento] project. Additionally, a URL will only be
 computed if the Vagrant provider is VirtualBox or is VMware based (these are
 the only providers with downloadable base boxes).
+
+### <a name="config-box-download-ca-cert"></a> box\_download\_ca\_cert
+
+Path relative to the `.kitchen.yml` file for locating the trusted CA bundle.
+Useful when combined with `box_url`.
+
+The default is `nil`, indicating to use the default Mozilla CA cert bundle.
+See also `box_download_insecure`.
+
+### <a name="config-box-download-insecure"></a> box\_download\_insecure
+
+If true, then SSL certificates from the server will
+not be verified.
+
+The default is `false`, meaning if the URL is an HTTPS URL,
+then SSL certs will be verified.
 
 ### <a name="config-box-version"></a> box\_version
 

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -284,7 +284,8 @@ module Kitchen
       # @api private
       def render_template
         config[:box_download_ca_cert] = File.expand_path(
-          config[:box_download_ca_cert], config[:kitchen_root]) unless config[:box_download_ca_cert].nil?
+          config[:box_download_ca_cert], config[:kitchen_root]) unless
+            config[:box_download_ca_cert].nil?
         template = File.expand_path(
           config[:vagrantfile_erb], config[:kitchen_root])
 

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -45,6 +45,8 @@ module Kitchen
 
       default_config :box_download_insecure, nil
 
+      default_config :box_download_ca_cert, nil
+
       default_config(:box_url) { |driver| driver.default_box_url }
 
       default_config :box_version, nil
@@ -281,6 +283,8 @@ module Kitchen
       # @raise [ActionFailed] if the Vagrantfile template was not found
       # @api private
       def render_template
+        config[:box_download_ca_cert] = File.expand_path(
+          config[:box_download_ca_cert], config[:kitchen_root]) unless config[:box_download_ca_cert].nil?
         template = File.expand_path(
           config[:vagrantfile_erb], config[:kitchen_root])
 

--- a/lib/kitchen/driver/vagrant_version.rb
+++ b/lib/kitchen/driver/vagrant_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Vagrant Kitchen driver
-    VAGRANT_VERSION = "0.20.0"
+    VAGRANT_VERSION = "0.20.1"
   end
 end

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -207,7 +207,7 @@ describe Kitchen::Driver::Vagrant do
     it "sets :box_download_ca_cert to a custom value" do
       config[:box_download_ca_cert] = "cacert.pem"
 
-      expect(driver[:box_check_update]).to eq("cacert.pem")
+      expect(driver[:box_download_ca_cert]).to eq("cacert.pem")
     end
 
     it "sets :box_download_insecure to nil by default" do

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -200,6 +200,16 @@ describe Kitchen::Driver::Vagrant do
       expect(driver[:box_check_update]).to eq(true)
     end
 
+    it "sets :box_download_ca_cert to nil by default" do
+      expect(driver[:box_download_ca_cert]).to eq(nil)
+    end
+
+    it "sets :box_download_ca_cert to a custom value" do
+      config[:box_download_ca_cert] = "cacert.pem"
+
+      expect(driver[:box_check_update]).to eq("cacert.pem")
+    end
+
     it "sets :box_download_insecure to nil by default" do
       expect(driver[:box_download_insecure]).to eq(nil)
     end

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -18,6 +18,10 @@ Vagrant.configure("2") do |c|
   c.vm.box_check_update = "<%= config[:box_check_update] %>"
 <% end %>
 
+<% if !config[:box_download_ca_cert].nil? %>
+  c.vm.box_download_ca_cert = "<%= config[:box_download_ca_cert] %>"
+<% end %>
+
 <% if !config[:box_download_insecure].nil? %>
   c.vm.box_download_insecure = "<%= config[:box_download_insecure] %>"
 <% end %>


### PR DESCRIPTION
Specifying `box_download_ca_cert` under the platform driver will expand the file path relative to Kitchen Root and be put into the `Vagrantfile` (when using the default ERB template). Useful for people who don't want to resort to `box_download_insecure`, yet need a trusted certificate not in the default Mozilla CA file.
