### PR TITLE
Add a synced folder to persist chef omnibus packages

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -169,6 +169,13 @@ module Kitchen
         instance.transport.name.downcase =~ /win_?rm/
       end
 
+      # Setting up the `cache_directory` to store omnibus packages in cache
+      # and share a local folder to that directory so that we don't pull them
+      # down every single time
+      def cache_directory
+        windows_os? ? "$env:TEMP\\omnibus\\cache" : "/tmp/omnibus/cache"
+      end
+
       protected
 
       WEBSITE = "http://www.vagrantup.com/downloads.html".freeze
@@ -251,24 +258,18 @@ module Kitchen
         add_extra_synced_folders!
       end
 
-      # Verify if we are using the Provisioner::ChefBase that now has a
-      # config parameter for the Chef omnibus cache, if that is set then
-      # we would like to sync a local folder to the instance so we can
-      # take advantage of the cache packages that we might have,
-      # therefore we wont download a package we already have in the cache
+      # We would like to sync a local folder to the instance so we can
+      # take advantage of the packages that we might have in cache,
+      # therefore we wont download a package we already have
       def add_extra_synced_folders!
-        if chef_omnibus_cache
+        if cache_directory
           FileUtils.mkdir_p(local_kitchen_cache)
           config[:synced_folders].push([
             local_kitchen_cache,
-            chef_omnibus_cache,
+            cache_directory,
             "create: true"
           ])
         end
-      end
-
-      def chef_omnibus_cache
-        instance.provisioner[:chef_omnibus_cache] if instance
       end
 
       # Truncates the length of `:vm_hostname` to 12 characters for

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -360,6 +360,19 @@ describe Kitchen::Driver::Vagrant do
       ])
     end
 
+    describe "when chef_omnibus_cache is set" do
+      before do
+        allow(driver_object).to receive(:chef_omnibus_cache).
+          and_return("/tmp/path")
+      end
+
+      it "adds the extra synced folder for omnibus cache" do
+        expect(driver[:synced_folders]).to eq([
+          [File.expand_path("~/.kitchen/cache"), "/tmp/path", "create: true"]
+        ])
+      end
+    end
+
     it "sets :vagrant_binary to 'vagrant' by default" do
       expect(driver[:vagrant_binary]).to eq("vagrant")
     end

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -147,6 +147,14 @@ describe Kitchen::Driver::Vagrant do
 
   describe "configuration" do
 
+    let(:cache_directory_array) do
+      [
+        File.expand_path("~/.kitchen/cache"),
+        "/tmp/omnibus/cache",
+        "create: true"
+      ]
+    end
+
     %W[centos debian fedora opensuse ubuntu].each do |name|
 
       context "for known bento platform names starting with #{name}" do
@@ -316,8 +324,8 @@ describe Kitchen::Driver::Vagrant do
       expect(driver[:ssh]).to eq(:a => "b", :c => { :d => "e" })
     end
 
-    it "sets :synced_folders to an empty array by default" do
-      expect(driver[:synced_folders]).to eq([])
+    it "sets :synced_folders with the cache_directory by default" do
+      expect(driver[:synced_folders]).to eq([cache_directory_array])
     end
 
     it "sets :synced_folders to a custom value" do
@@ -326,7 +334,11 @@ describe Kitchen::Driver::Vagrant do
       ]
 
       expect(driver[:synced_folders]).to eq([
-        [File.expand_path("/host_path"), "/vm_path", "create: true, type: :nfs"]
+        [
+          File.expand_path("/host_path"),
+          "/vm_path", "create: true, type: :nfs"
+        ],
+        cache_directory_array
       ])
     end
 
@@ -336,7 +348,8 @@ describe Kitchen::Driver::Vagrant do
       ]
 
       expect(driver[:synced_folders]).to eq([
-        [File.expand_path("/root/suitey-fooos-99"), "/vm_path", "stuff"]
+        [File.expand_path("/root/suitey-fooos-99"), "/vm_path", "stuff"],
+        cache_directory_array
       ])
     end
 
@@ -346,7 +359,8 @@ describe Kitchen::Driver::Vagrant do
       ]
 
       expect(driver[:synced_folders]).to eq([
-        [File.expand_path("/kroot/a"), "/vm_path", "stuff"]
+        [File.expand_path("/kroot/a"), "/vm_path", "stuff"],
+        cache_directory_array
       ])
     end
 
@@ -356,21 +370,9 @@ describe Kitchen::Driver::Vagrant do
       ]
 
       expect(driver[:synced_folders]).to eq([
-        [File.expand_path("/host_path"), "/vm_path", "nil"]
+        [File.expand_path("/host_path"), "/vm_path", "nil"],
+        cache_directory_array
       ])
-    end
-
-    describe "when chef_omnibus_cache is set" do
-      before do
-        allow(driver_object).to receive(:chef_omnibus_cache).
-          and_return("/tmp/path")
-      end
-
-      it "adds the extra synced folder for omnibus cache" do
-        expect(driver[:synced_folders]).to eq([
-          [File.expand_path("~/.kitchen/cache"), "/tmp/path", "create: true"]
-        ])
-      end
     end
 
     it "sets :vagrant_binary to 'vagrant' by default" do
@@ -431,6 +433,14 @@ describe Kitchen::Driver::Vagrant do
 
     context "for windows os_types" do
 
+      let(:win_cache_directory_array) do
+        [
+          File.expand_path("~/.kitchen/cache"),
+          "$env:TEMP\\omnibus\\cache",
+          "create: true"
+        ]
+      end
+
       before { allow(platform).to receive(:os_type).and_return("windows") }
 
       it "sets :vm_hostname to nil by default" do
@@ -441,6 +451,21 @@ describe Kitchen::Driver::Vagrant do
         config[:vm_hostname] = "this-is-a-pretty-long-name-ya-think"
 
         expect(driver[:vm_hostname]).to eq("this-is-a--k")
+      end
+
+      it "sets :synced_folders with the cache_directory by default" do
+        expect(driver[:synced_folders]).to eq([win_cache_directory_array])
+      end
+
+      it "replaces %{instance_name} with instance name in :synced_folders" do
+        config[:synced_folders] = [
+          ["/root/%{instance_name}", "/vm_path", "stuff"]
+        ]
+
+        expect(driver[:synced_folders]).to eq([
+          [File.expand_path("/root/suitey-fooos-99"), "/vm_path", "stuff"],
+          win_cache_directory_array
+        ])
       end
     end
   end


### PR DESCRIPTION
Setting up the new `chef_directory` interface within the Driver. Then with this directory we will allow the the instance to have a cache directory where omnitruck will download the artifacts, so we can cache the packages locally and avoid re-pulling down artifacts that you already have on your workstation.

Signed-off-by: Salim Afiune <afiune@chef.io>