### PR TITLE
Fix cache directory on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,23 @@ Vagrant.configure("2") do |config|
 end
 ```
 
+### <a name="config-cache_directory"></a> cache_directory
+
+Customize the cache directory on the instance. This parameter must be an
+absolute path.
+
+The defaults are:
+* Windows: `C:\\omnibus\\cache`
+* Unix: `/tmp/omnibus/cache`
+
+The example:
+
+```yaml
+---
+driver:
+  cache_directory: Z:\\custom\\cache
+```
+
 ### <a name="config-vagrantfile-erb"></a> vagrantfile\_erb
 
 An alternate Vagrantfile ERB template that will be rendered for use by this

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -173,7 +173,7 @@ module Kitchen
       # and share a local folder to that directory so that we don't pull them
       # down every single time
       def cache_directory
-        windows_os? ? "$env:TEMP\\omnibus\\cache" : "/tmp/omnibus/cache"
+        windows_os? ? "C:\\omnibus\\cache" : "/tmp/omnibus/cache"
       end
 
       protected

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -84,6 +84,10 @@ module Kitchen
         driver.windows_os? ? nil : driver.instance.name
       end
 
+      default_config(:cache_directory) do |driver|
+        driver.windows_os? ? "C:\\omnibus\\cache" : "/tmp/omnibus/cache"
+      end
+
       no_parallel_for :create, :destroy
 
       # Creates a Vagrant VM instance.
@@ -173,7 +177,7 @@ module Kitchen
       # and share a local folder to that directory so that we don't pull them
       # down every single time
       def cache_directory
-        windows_os? ? "C:\\omnibus\\cache" : "/tmp/omnibus/cache"
+        config[:cache_directory]
       end
 
       protected

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -436,7 +436,7 @@ describe Kitchen::Driver::Vagrant do
       let(:win_cache_directory_array) do
         [
           File.expand_path("~/.kitchen/cache"),
-          "$env:TEMP\\omnibus\\cache",
+          "C:\\omnibus\\cache",
           "create: true"
         ]
       end

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -468,6 +468,34 @@ describe Kitchen::Driver::Vagrant do
         ])
       end
     end
+
+    context "when cache_directory is customized" do
+
+      let(:custom_cache_directory_array) do
+        [
+          File.expand_path("~/.kitchen/cache"),
+          "Z:\\awesome\\cache",
+          "create: true"
+        ]
+      end
+
+      before { config[:cache_directory] = 'Z:\\awesome\\cache' }
+
+      it "sets :synced_folders with the custom cache_directory" do
+        expect(driver[:synced_folders]).to eq([custom_cache_directory_array])
+      end
+
+      it "replaces %{instance_name} with instance name in :synced_folders" do
+        config[:synced_folders] = [
+          ["/root/%{instance_name}", "/vm_path", "stuff"]
+        ]
+
+        expect(driver[:synced_folders]).to eq([
+          [File.expand_path("/root/suitey-fooos-99"), "/vm_path", "stuff"],
+          custom_cache_directory_array
+        ])
+      end
+    end
   end
 
   describe "#verify_dependencies" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 
 if ENV["CODECLIMATE_REPO_TOKEN"]
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
+  require 'simplecov'
+  SimpleCov.start
 elsif ENV["COVERAGE"]
   require "simplecov"
   SimpleCov.profiles.define "gem" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 if ENV["CODECLIMATE_REPO_TOKEN"]
-  require 'simplecov'
+  require "simplecov"
   SimpleCov.start
 elsif ENV["COVERAGE"]
   require "simplecov"


### PR DESCRIPTION
We are going to default to `C` Drive since vagrant does not know about
the environament variables of the guest VM.

Closes https://github.com/test-kitchen/kitchen-vagrant/issues/250

Signed-off-by: Salim Afiune <afiune@chef.io>