### PR TITLE
Vagrant requires also to scape slashes

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1216,6 +1216,19 @@ describe Kitchen::Driver::Vagrant do
       RUBY
     end
 
+    it "vm.synced_folder scapes the back slashes for Windows paths" do
+      config[:synced_folders] = [
+        ["/a/b", "C:\\opt\\instance_data", "nil"],
+        ["Z:\\host_path", "/vm_path", "create: true"]
+      ]
+      cmd
+
+      expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {6}/, "").chomp))
+        c.vm.synced_folder "/a/b", "C:\\\\opt\\\\instance_data", nil
+        c.vm.synced_folder "Z:\\\\host_path", "/vm_path", create: true
+      RUBY
+    end
+
     context "for virtualbox provider" do
 
       before { config[:provider] = "virtualbox" }

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -72,7 +72,7 @@ Vagrant.configure("2") do |c|
 
   c.vm.synced_folder ".", "/vagrant", disabled: true
 <% config[:synced_folders].each do |source, destination, options| %>
-  c.vm.synced_folder "<%= source %>", "<%= destination %>", <%= options %>
+  c.vm.synced_folder <%= source.inspect %>, <%= destination.inspect %>, <%= options %>
 <% end %>
 
   c.vm.provider :<%= config[:provider] %> do |p|


### PR DESCRIPTION
We need to scape the back slashes in Ruby but also Vagrant requires to
scape them. So we need to double scape!

Signed-off-by: Salim Afiune <afiune@chef.io>