### PR TITLE
add oracle as supported bento-box type

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -205,7 +205,7 @@ module Kitchen
       #   box
       # @api private
       def bento_box?(name)
-        name =~ /^(centos|debian|fedora|freebsd|opensuse|ubuntu)-/
+        name =~ /^(centos|debian|fedora|freebsd|opensuse|ubuntu|oracle)-/
       end
 
       # Renders and writes out a Vagrantfile dedicated to this instance.


### PR DESCRIPTION
Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>