### PR TITLE
Change default cache dir for Windows

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -85,7 +85,7 @@ module Kitchen
       end
 
       default_config(:cache_directory) do |driver|
-        driver.windows_os? ? "C:\\omnibus\\cache" : "/tmp/omnibus/cache"
+        driver.windows_os? ? "/omnibus/cache" : "/tmp/omnibus/cache"
       end
 
       no_parallel_for :create, :destroy

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -436,7 +436,7 @@ describe Kitchen::Driver::Vagrant do
       let(:win_cache_directory_array) do
         [
           File.expand_path("~/.kitchen/cache"),
-          "C:\\omnibus\\cache",
+          "/omnibus/cache",
           "create: true"
         ]
       end


### PR DESCRIPTION
We are not allow to use the DRIVE C: when sharing a folder in
vagrant/virtualbox because Windows doesn't like the fact that you have
the colon.

We now default to `/omnibus/cache` that Windows will understand as:
```
%SYSTEMDRIVE%/omnibus/cache
```

Signed-off-by: Salim Afiune <afiune@chef.io>