### PR TITLE
Exclude freebsd and ability to disable cache dir

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -177,7 +177,7 @@ module Kitchen
       # and share a local folder to that directory so that we don't pull them
       # down every single time
       def cache_directory
-        return if windows_host? && config[:provider] != "virtualbox"
+        return if disable_cache?
         config[:cache_directory]
       end
 
@@ -207,6 +207,22 @@ module Kitchen
       # @api private
       def bento_box?(name)
         name =~ /^(centos|debian|fedora|freebsd|opensuse|ubuntu|oracle)-/
+      end
+
+      # Return true if we found the criteria to disable the cache_directory
+      # functionality
+      def disable_cache?
+        # Disable for Windows not using Virtualbox
+        if windows_host? && config[:provider] != "virtualbox" ||
+            # Disable for FreeBSD
+            instance.platform.name == "freebsd" ||
+            # Disable if cache_directory is set to "false" on .kitchen.yml
+            !config[:cache_directory]
+          return true
+        end
+
+        # Otherwise
+        false
       end
 
       # Renders and writes out a Vagrantfile dedicated to this instance.

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -157,7 +157,7 @@ describe Kitchen::Driver::Vagrant do
       ]
     end
 
-    %W[centos debian fedora opensuse ubuntu].each do |name|
+    %W[centos debian fedora opensuse ubuntu oracle freebsd].each do |name|
 
       context "for known bento platform names starting with #{name}" do
 
@@ -334,6 +334,11 @@ describe Kitchen::Driver::Vagrant do
       allow(RbConfig::CONFIG).to receive(:[]).with("host_os").
         and_return("mingw")
       config[:provider] = "notvbox"
+      expect(driver[:synced_folders]).to eq([])
+    end
+
+    it "does not set :synced_folders to cache_directory on freebsd systems" do
+      allow(platform).to receive(:name).and_return("freebsd")
       expect(driver[:synced_folders]).to eq([])
     end
 


### PR DESCRIPTION
We are excluding FreeBSD systems and also adding the ability to disable
the `cache_directory` by setting it up to `false` in the `kitchen.yml`
file.

Example:
```yaml
platforms:
- name: ubuntu-12.04
  driver:
    cache_directory: false
```

Closes https://github.com/test-kitchen/kitchen-vagrant/issues/260
Closes https://github.com/test-kitchen/kitchen-vagrant/issues/256
Closes https://github.com/test-kitchen/kitchen-vagrant/issues/257

Signed-off-by: Salim Afiune <afiune@chef.io>

cc/ @test-kitchen/maintainers 