### PR TITLE
pin to rake 11.3 to fix builds

### DIFF
--- a/kitchen-vagrant.gemspec
+++ b/kitchen-vagrant.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "test-kitchen", "~> 1.4"
 
   gem.add_development_dependency "countloc",  "~> 0.4"
-  gem.add_development_dependency "rake"
+  gem.add_development_dependency "rake",      "~> 11.3"
   gem.add_development_dependency "rspec",     "~> 3.2"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "github_changelog_generator", "1.11.3"


### PR DESCRIPTION
This is temporary to get builds green. Rake 12.0 released a few days ago broke builds. We addressed this in TK by switching to chefstyle from finstyle which had an older version of rubocop that caused the damage with the newer rake. We should do the same here asap.