### PR TITLE
Fix #186 (mostly) and make it easy to use vagrant-cachier

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,28 @@ Many host wide defaults for Vagrant can be set using `$HOME/.vagrant.d/Vagrantfi
 
 ## <a name="config"></a> Configuration
 
+### <a name="config-cachier"></a> cachier
+
+Enable and configure scope for [vagrant-cachier][vagrant_cachier] plugin.
+Valid options are `:box` or `:machine`, setting to a truthy value yields `:box`
+
+For example:
+
+```yaml
+---
+driver:
+  cachier: true
+```
+
+will generate a Vagrantfile configuration similar to:
+
+```ruby
+  config.cache.scope = :box
+```
+
+The default is `nil`, indicating unset.
+
+
 ### <a name="config-box"></a> box
 
 **Required** This determines which Vagrant box will be used. For more
@@ -536,3 +558,4 @@ Apache 2.0 (see [LICENSE][license])
 [atlas]:                    https://atlas.hashicorp.com/
 [parallels_dl]:             http://www.parallels.com/products/desktop/download/
 [vagrant_parallels]:        https://github.com/Parallels/vagrant-parallels
+[vagrant_cachier]:        https://github.com/fgrehm/vagrant-cachier

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -88,6 +88,8 @@ module Kitchen
         driver.windows_os? ? "/omnibus/cache" : "/tmp/omnibus/cache"
       end
 
+      default_config :cachier, nil
+
       no_parallel_for :create, :destroy
 
       # Creates a Vagrant VM instance.

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -955,6 +955,27 @@ describe Kitchen::Driver::Vagrant do
       ))
     end
 
+    it "sets no cache.scope if missing" do
+      config[:cachier] = nil
+      cmd
+
+      expect(vagrantfile).to_not match(regexify(%{c.cache.scope}, :partial))
+    end
+
+    it "sets cache.scope to :box if :cachier is set" do
+      config[:cachier] = true
+      cmd
+
+      expect(vagrantfile).to match(regexify(%{c.cache.scope = :box}))
+    end
+
+    it "sets cache.scope if :cachier is set to a custom value" do
+      config[:cachier] = ":machine"
+      cmd
+
+      expect(vagrantfile).to match(regexify(%{c.cache.scope = :machine}))
+    end
+
     it "sets the vm.box" do
       cmd
 

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -4,6 +4,12 @@ require "<%= vagrantfile %>"
 
 Vagrant.configure("2") do |c|
   c.berkshelf.enabled = false if Vagrant.has_plugin?("vagrant-berkshelf")
+  <% if config[:cachier] %>
+  if Vagrant.has_plugin?("vagrant-cachier")
+    c.cache.scope = <%= [':box', ':machine'].include?(config[:cachier]) ? config[:cachier] : ':box' %>
+  end
+  <% end %>
+
   c.vm.box = "<%= config[:box] %>"
 
 <% if config[:box_url] %>


### PR DESCRIPTION
Adds support `vagrant-cachier` but doesn't make it default
- mostly fix #186, at least in spirit
- supersedes #200

Signed-off-by: Seth Thomas <sthomas@chef.io>