### PR TITLE
Make kitchen package work

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -135,6 +135,20 @@ module Kitchen
         state.delete(:hostname)
       end
 
+      def package(state)
+        if state[:hostname].nil?
+          raise UserError, "Vagrant instance not created!"
+        end
+        if not (config[:ssh] && config[:ssh][:insert_key] == false)
+          m = "Disable vagrant ssh key replacement to preserve the default key!"
+          warn(m)
+        end
+        instance.transport.connection(state).close
+        box_name = File.join(Dir.pwd, instance.name + ".box")
+        run("#{config[:vagrant_binary]} package --output #{box_name}")
+        destroy(state)
+      end
+
       # A lifecycle method that should be invoked when the object is about
       # ready to be used. A reference to an Instance is required as
       # configuration dependant data may be access through an Instance. This


### PR DESCRIPTION
Tested with the following config:
```
---
driver:
  name: vagrant
  provider: lxc

provisioner:
  name: chef_zero

platforms:
  - name: xenial64-lxc
    driver_plugin: vagrant
    driver_config:
      box: hrishikeshdate/xenial64
      ssh:
        insert_key: false

suites:
  - name: mysuite
    run_list:
      - recipe[mycookbook::default]
```