### PR TITLE
Exclude cache directory mount on osx / macos instances because of issues on virtualbox

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -221,6 +221,8 @@ module Kitchen
         if windows_host? && config[:provider] != "virtualbox" ||
             # Disable for FreeBSD
             instance.platform.name == "freebsd" ||
+            # Disable for macos / osx
+            instance.platform.name =~ /(macos|osx)/ ||
             # Disable if cache_directory is set to "false" on .kitchen.yml
             !config[:cache_directory]
           return true

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -352,6 +352,16 @@ describe Kitchen::Driver::Vagrant do
       expect(driver[:synced_folders]).to eq([])
     end
 
+    it "does not set :synced_folders to cache_directory on macos systems" do
+      allow(platform).to receive(:name).and_return("macos")
+      expect(driver[:synced_folders]).to eq([])
+    end
+
+    it "does not set :synced_folders to cache_directory on osx systems" do
+      allow(platform).to receive(:name).and_return("osx")
+      expect(driver[:synced_folders]).to eq([])
+    end
+
     it "sets :synced_folders to a custom value" do
       config[:synced_folders] = [
         ["/host_path", "/vm_path", "create: true, type: :nfs"],


### PR DESCRIPTION
This will fix an issue for users trying to run on macos, it can already be achieved by setting the cache_directory to false in the kitchen.yml file but that is a work around.  This solves #280 for the OS's @cheeseplus mentioned.