### PR TITLE
Fix a bug can be occurred when `instance` returns `nil`

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -469,10 +469,13 @@ module Kitchen
       #   instance's Vagrantfile
       # @api private
       def vagrant_root
-        root = File.join(config[:kitchen_root], %w{.kitchen kitchen-vagrant},
-          "kitchen-#{File.basename(config[:kitchen_root])}-#{instance.name}"
-        )
-        @vagrant_root ||= instance.nil? ? nil : root
+        if !@vagrant_root && !instance.nil?
+          @vagrant_root = File.join(
+            config[:kitchen_root], %w{.kitchen kitchen-vagrant},
+            "kitchen-#{File.basename(config[:kitchen_root])}-#{instance.name}"
+          )
+        end
+        @vagrant_root
       end
 
       # @param type [Symbol] either `:ssh` or `:winrm`

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -48,6 +48,10 @@ describe Kitchen::Driver::Vagrant do
     d
   end
 
+  let(:driver_with_no_instance) do
+    driver_object
+  end
+
   let(:instance) do
     Kitchen::Instance.new(
       :verifier => verifier,
@@ -538,6 +542,12 @@ describe Kitchen::Driver::Vagrant do
       with_modern_vagrant
 
       driver.verify_dependencies
+    end
+
+    it "passes for supported versions of Vagrant when it has no instances" do
+      with_modern_vagrant
+
+      driver_with_no_instance.verify_dependencies
     end
 
     it "raises a UserError for unsupported versions of Vagrant" do


### PR DESCRIPTION
I got the following error message ([full error message](https://gist.github.com/Kuniwak/83e60be11445d1f859a5e58590c78afa)) when executing `kitchen list`:

```console
$ kitchen list
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ClientError
>>>>>> Message: Could not load the 'vagrant' driver from the load path. Please ensure that your driver is installed as a gem or included in your Gemfile if using Bundler.
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

This message said that "`kitchen-vagrant` was not installed," but `kitchen-vagrant` was listed by `bundle list` and `require("kitchen/driver/vagrant.rb")` did not raise `LoadError`.

I think this problem is caused by e788314e0c846765da8358619a87e2128bdab955. After this commit, the error ``undefined method `name' for nil:NilClass`` can be occurred when `instance` returns `nil`, because `instance.name` is accessed before `nil` check for `instance`.