### PR TITLE
Add support for all misc vagrant providers

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -185,7 +185,7 @@ Vagrant.configure("2") do |c|
     <% else %>
     p.vmx["<%= key %>"] = "<%= value %>"
     <% end %>
-  <% when "openstack", "cloudstack", "hyperv", "ovirt3", "rackspace", "aws" %>
+  <% else %>
     <% if value.is_a? String %>
     p.<%= key %> = "<%= value%>"
     <% else  %>


### PR DESCRIPTION
This negates #289 

Not sure what tests look like but a sanity syntax check passed:

```
$ erb -x -T  '-' Vagrantfile.erb  | ruby -c
Syntax OK
```