### PR TITLE
Adds ability to override Kitchen cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ end
 
 ### <a name="config-cache_directory"></a> cache_directory
 
-Customize the cache directory on the instance. This parameter must be an
+Customize the cache directory on the Vagrant instance. This parameter must be an
 absolute path.
 
 The defaults are:
@@ -476,6 +476,23 @@ The example:
 ---
 driver:
   cache_directory: Z:\\custom\\cache
+```
+
+### <a name="config-kitchen_cache_directory"></a> kitchen_cache_directory
+
+Customize the kitchen cache directory on the system running Test Kitchen. This parameter must be an
+absolute path.
+
+The defaults are:
+* Windows: `~/.kitchen/cache`
+* Unix: `~/.kitchen/cache`
+
+The example:
+
+```yaml
+---
+driver:
+  kitchen_cache_directory: Z:\\custom\\kitchen_cache
 ```
 
 ### <a name="config-vagrantfile-erb"></a> vagrantfile\_erb

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -90,6 +90,9 @@ module Kitchen
         driver.windows_os? ? "/omnibus/cache" : "/tmp/omnibus/cache"
       end
 
+      default_config :kitchen_cache_directory,
+        File.expand_path("~/.kitchen/cache")
+
       default_config :cachier, nil
 
       no_parallel_for :create, :destroy
@@ -462,7 +465,7 @@ module Kitchen
       # @return [String] full absolute path to the kitchen cache directory
       # @api private
       def local_kitchen_cache
-        @local_kitchen_cache ||= File.expand_path("~/.kitchen/cache")
+        @local_kitchen_cache ||= config[:kitchen_cache_directory]
       end
 
       # @return [String] full local path to the directory containing the


### PR DESCRIPTION
Adds the ability to override the location of the Kitchen cache to something other than '~/.kitchen/cache'.

The main driver here is that we map our home drives to a UNC path which is fine in the office, but quite slow over the VPN. As a result, I have to redirect many folder homes to a local path.