### PR TITLE
Create an ssh/winrm-config file in the instance dir

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -662,10 +662,24 @@ describe Kitchen::Driver::Vagrant do
       )
     end
 
+    it "logs a message at debug when creating the ssh/winrm-config files" do
+      cmd
+
+      expect(logged_output.string).to match(
+        /^D, .+ DEBUG -- : .+ (ssh|winrm)-config file.+ \<suitey-fooos-99\>/
+      )
+    end
+
     it "creates a Vagrantfile in the vagrant root directory" do
       cmd
 
       expect(File.exist?(File.join(vagrant_root, "Vagrantfile"))).to eq(true)
+    end
+
+    it "creates an ssh-config file in the vagrant root directory" do
+      cmd
+
+      expect(File.exist?(File.join(vagrant_root, "ssh-config"))).to eq(true)
     end
 
     it "calls Transport's #wait_until_ready" do
@@ -674,6 +688,20 @@ describe Kitchen::Driver::Vagrant do
       expect(conn).to receive(:wait_until_ready)
 
       cmd
+    end
+
+    context "when the winrm plugin is installed" do
+      before do
+        allow(driver_object).to receive(:winrm_plugin_installed?).
+          and_return(true)
+      end
+
+      it "creates a winrm-config file in the vagrant root directory" do
+        cmd
+
+        expect(File.exist?(File.join(vagrant_root,
+                                     "winrm-config"))).to eq(true)
+      end
     end
 
     it "logs the Vagrantfile contents on debug level" do
@@ -749,7 +777,12 @@ describe Kitchen::Driver::Vagrant do
         before do
           allow(transport).to receive(:name).and_return("Coolness")
           allow(driver).to receive(:run_command).
-            with("vagrant ssh-config", any_args).and_return(output)
+            with("vagrant ssh-config").with(any_args).and_return(output)
+        end
+
+        it "creates an ssh-config file with content" do
+          cmd
+          expect(ssh_config).to match(/Host hehe/)
         end
 
         it "sets :hostname from ssh-config" do
@@ -819,7 +852,12 @@ describe Kitchen::Driver::Vagrant do
         before do
           allow(transport).to receive(:name).and_return("WinRM")
           allow(driver).to receive(:run_command).
-            with("vagrant winrm-config", any_args).and_return(output)
+            with("vagrant winrm-config").with(any_args).and_return(output)
+        end
+
+        it "creates a winrm-config file with content" do
+          cmd
+          expect(ssh_config).to match(/Host hehe/)
         end
 
         it "sets :hostname from winrm-config" do
@@ -2020,5 +2058,9 @@ describe Kitchen::Driver::Vagrant do
 
   def vagrantfile
     IO.read(File.join(vagrant_root, "Vagrantfile"))
+  end
+
+  def ssh_config
+    IO.read(File.join(vagrant_root, "ssh-config"))
   end
 end


### PR DESCRIPTION
I thought it already did this.. turns out it doesn't.
Makes integrating with other tools a tad easier.

`any_args` doesn't seem to work the way the test implied:

```ruby
From: /Users/isa/Development/github.com/curiositycasualty/kitchen-vagrant/spec/kitchen/driver/vagrant_spec.rb @ line 785 :

    780:         end
    781:
    782:         it "ugh" do
    783:           cmd
    784:           require 'pry'; binding.pry
 => 785:         end
    786:
    787:         it "sets :hostname from ssh-config" do
    788:           cmd
    789:
    790:           expect(state).to include(:hostname => "192.168.32.64")

[1] pry(#<RSpec::ExampleGroups::KitchenDriverVagrant::Create::ForState::ForNonWinRMBasedTransports>)> cd driver
[2] pry(#<Kitchen::Driver::Vagrant>):1> run_command("vagrant ssh-config")
=> "  Host hehe\n" +
"    HostName 192.168.32.64\n" +
"    User vagrant\n" +
"    Port 2022\n" +
"    UserKnownHostsFile /dev/null\n" +
"    StrictHostKeyChecking no\n" +
"    PasswordAuthentication no\n" +
"    IdentityFile /path/to/private_key\n" +
"    IdentitiesOnly yes\n" +
"    LogLevel FATAL\n"
[3] pry(#<Kitchen::Driver::Vagrant>):1> run_command("vagrant ssh-config wat")
=> ""
[4] pry(#<Kitchen::Driver::Vagrant>):1> exit-program
```

but:

```ruby
From: /Users/isa/Development/github.com/curiositycasualty/kitchen-vagrant/spec/kitchen/driver/vagrant_spec.rb @ line 785 :

    780:         end
    781:
    782:         it "ugh" do
    783:           cmd
    784:           require 'pry'; binding.pry
 => 785:         end
    786:
    787:         it "sets :hostname from ssh-config" do
    788:           cmd
    789:
    790:           expect(state).to include(:hostname => "192.168.32.64")

[1] pry(#<RSpec::ExampleGroups::KitchenDriverVagrant::Create::ForState::ForNonWinRMBasedTransports>)> cd driver
[2] pry(#<Kitchen::Driver::Vagrant>):1> run_command("vagrant ssh-config wat")
=> "  Host hehe\n" +
"    HostName 192.168.32.64\n" +
"    User vagrant\n" +
"    Port 2022\n" +
"    UserKnownHostsFile /dev/null\n" +
"    StrictHostKeyChecking no\n" +
"    PasswordAuthentication no\n" +
"    IdentityFile /path/to/private_key\n" +
"    IdentitiesOnly yes\n" +
"    LogLevel FATAL\n"
[3] pry(#<Kitchen::Driver::Vagrant>):1> run_command("vagrant ssh-config")
=> "  Host hehe\n" +
"    HostName 192.168.32.64\n" +
"    User vagrant\n" +
"    Port 2022\n" +
"    UserKnownHostsFile /dev/null\n" +
"    StrictHostKeyChecking no\n" +
"    PasswordAuthentication no\n" +
"    IdentityFile /path/to/private_key\n" +
"    IdentitiesOnly yes\n" +
"    LogLevel FATAL\n"
```

Now with more cane friendliness (but uglier code)