### PR TITLE
Fix bug in Vagrantfile template related to WinRM options (missed quote)

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -68,7 +68,7 @@ Vagrant.configure("2") do |c|
 <% end %>
 <% if config[:winrm] %>
   <% config[:winrm].each do |key, value| %>
-    c.winrm.<%= key %> = <%= value %>
+    c.winrm.<%= key %> = "<%= value %>"
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Setup of WinRM options breaks Kitchen, `.kitchen.yml`:

```
driver:
  name: vagrant
  winrm:
    username: Administrator
    password: password
```

Error:

```
/.../.kitchen/kitchen-vagrant/.../Vagrantfile:4: syntax error, unexpected tIDENTIFIER, expecting keyword_end
```

Reason: missed quote around WinRM values in `Vagrantfile`