### PR TITLE
Fix detection of vagrant-winrm plugin.

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -561,7 +561,7 @@ module Kitchen
 
         self.class.winrm_plugin_passed = run_silently(
           "#{config[:vagrant_binary]} plugin list", :cwd => Dir.pwd).
-          split("\n").find { |line| line =~ /^vagrant-winrm\s+/ }
+          split("\n").find { |line| line =~ /vagrant-winrm\s+/ }
       end
     end
   end


### PR DESCRIPTION
Due to some Windows shell vagaries, exact line regex matching on vagrant-winrm plugin is failing. Loosening up the regex just a little bit allows it to succeed. There's a very low probability of matching the wrong vagrant plugin, but it is possible I suppose.
Certain Windows shells are colorizing the output of the command `vagrant plugin list`, which is causing the match failure. Wild theory, could be a change due to Windows Anniversary Update, as they've been making fundamental changes to the command shells.