### PR TITLE
Support to create/attach multiple additional VirtualBox disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ and [VMware][vagrant_config_vmware] for more details.
 #### <a name="config-customize-virtualbox-disk"></a> VirtualBox additional disk
 
 Adding the `createhd` and `storageattach` keys in `customize` allows for creation
-of an additional disk in VirtualBox. Full paths must be used as required by VirtualBox.
+of additional disks in VirtualBox. Full paths must be used as required by VirtualBox.
 
 *NOTE*: IDE Controller based drives always show up in the boot order first, regardless of if they
 are [bootable][vbox_ide_boot].
@@ -278,14 +278,21 @@ are [bootable][vbox_ide_boot].
 driver:
   customize:
     createhd:
-      filename: /tmp/disk1.vmdk
-      size: 1024
+      - filename: /tmp/disk1.vmdk
+        size: 1024
+      - filename: /tmp/disk2.vmdk
+        size: 2048
     storageattach:
-      storagectl: SATA Controller
-      port: 1
-      device: 0
-      type: hdd
-      medium: /tmp/disk1.vmdk
+      - storagectl: IDE Controller
+        port: 1
+        device: 0
+        type: hdd
+        medium: /tmp/disk2.vmdk
+      - storagectl: IDE Controller
+        port: 1
+        device: 1
+        type: hdd
+        medium: /tmp/disk2.vmdk
 ```
 
 will generate a Vagrantfile configuration similar to:

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -152,18 +152,24 @@ Vagrant.configure("2") do |c|
     <% end %>
   <% when "virtualbox" %>
     <% if key == :createhd %>
-    p.customize ["createhd", "--filename", "<%= value[:filename] %>", "--size", <%= value[:size] %>]
+      <% value = [value] unless value.instance_of?(Array) %>
+      <% value.each do |item| %>
+    p.customize ["createhd", "--filename", "<%= item[:filename] %>", "--size", <%= item[:size] %>]
+      <% end %>
     <% elsif key == :storageattach %>
-      <% options = [] %>
-      <% value.each do |storageattach_option_key, storageattach_option_value|
-           options << "\"--#{storageattach_option_key}\""
-           if storageattach_option_value.instance_of? Fixnum
-             options << storageattach_option_value
-           else
-             options << "\"#{storageattach_option_value}\""
-           end
-         end %>
+      <% value = [value] unless value.instance_of?(Array) %>
+      <% value.each do |item| %>
+        <% options = [] %>
+        <% item.each do |storageattach_option_key, storageattach_option_value|
+             options << "\"--#{storageattach_option_key}\""
+             if storageattach_option_value.instance_of? Fixnum
+               options << storageattach_option_value
+             else
+               options << "\"#{storageattach_option_value}\""
+             end
+           end %>
     p.customize ["storageattach", :id, <%= options.join(', ') %>]
+    <% end %>
     <% elsif key == :cpuidset %>
       <% ids = [] %>
       <% value.each do | id |


### PR DESCRIPTION
Currently the VagrantFile template supports when using the VirtualBox provider to attach **one** additional disk:
```yaml
driver:
  customize:
    createhd:
      filename: /tmp/disk1.vmdk
      size: 1024
    storageattach:
      storagectl: SATA Controller
      port: 1
      device: 0
      type: hdd
      medium: /tmp/disk1.vmdk
```

This PR extends this to allow to attach **multiple** additional disks by using an array syntax:
```yaml
driver:
  customize:
    createhd:
      - filename: /tmp/disk1.vmdk
        size: 1024
      - filename: /tmp/disk2.vmdk
        size: 2048
    storageattach:
      - storagectl: IDE Controller
        port: 1
        device: 0
        type: hdd
        medium: /tmp/disk2.vmdk
      - storagectl: IDE Controller
        port: 1
        device: 1
        type: hdd
        medium: /tmp/disk2.vmdk
```

The original syntax is still supported, for backward compatibility.