### PR TITLE
turn off caching, even for bento boxes

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -86,7 +86,9 @@ module Kitchen
         driver.windows_os? ? nil : "#{driver.instance.name}.vagrantup.com"
       end
 
-      default_config :cache_directory, false
+      default_config(:cache_directory) do |driver|
+        driver.windows_os? ? "/omnibus/cache" : "/tmp/omnibus/cache"
+      end
 
       default_config :kitchen_cache_directory,
         File.expand_path("~/.kitchen/cache")
@@ -197,10 +199,10 @@ module Kitchen
       # and share a local folder to that directory so that we don't pull them
       # down every single time
       def cache_directory
-        if enable_cache? && !config[:cache_directory]
-          windows_os? ? "/omnibus/cache" : "/tmp/omnibus/cache"
-        else
+        if enable_cache?
           config[:cache_directory]
+        else
+          false
         end
       end
 
@@ -244,9 +246,8 @@ module Kitchen
       # Return true if we found the criteria to enable the cache_directory
       # functionality
       def enable_cache?
-        if safe_share?(config[:box])
-          return true
-        end
+        return false unless config[:cache_directory]
+        return true if safe_share?(config[:box])
         # Otherwise
         false
       end

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -345,6 +345,12 @@ describe Kitchen::Driver::Vagrant do
       expect(driver[:synced_folders]).to eq([cache_directory_array])
     end
 
+    it "does not set :synced_folders when cache_directory is false" do
+      config[:box] = "bento/centos-99"
+      config[:cache_directory] = false
+      expect(driver[:synced_folders]).to eq([])
+    end
+
     it "does not set :synced_folders to cache_directory on freebsd systems" do
       allow(platform).to receive(:name).and_return("freebsd-99")
       expect(driver[:synced_folders]).to eq([])
@@ -484,7 +490,10 @@ describe Kitchen::Driver::Vagrant do
         ]
       end
 
-      before { config[:cache_directory] = 'Z:\\awesome\\cache' }
+      before do
+        config[:box] = "bento/centos-99"
+        config[:cache_directory] = "Z:\\awesome\\cache"
+      end
 
       it "sets :synced_folders with the custom cache_directory" do
         expect(driver[:synced_folders]).to eq([custom_cache_directory_array])


### PR DESCRIPTION
+ moved the setting of the default values for cache_directory up to the
  default_config declaration section
+ added fast fail to `enable_cache?` for when a config declares the
  cache_directory to be false per the documentation
+ simplified the cache_directory getter to return the cache_directory
  only if `enable_cache?` criteria are met

+ some specs updated that expect to be caching, but did not meet
  `enable_cache?` criteria (using a bento)

Fixes #307 