### PR TITLE
remove cane testing, chefstyle will handle

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,12 +11,6 @@ end
 desc "Run all test suites"
 task :test => [:spec]
 
-require "cane/rake_task"
-desc "Run cane to check quality metrics"
-Cane::RakeTask.new do |cane|
-  cane.canefile = "./.cane"
-end
-
 require "chefstyle"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new(:style) do |task|
@@ -32,7 +26,7 @@ task :stats do
 end
 
 desc "Run all quality tasks"
-task :quality => [:cane, :style, :stats]
+task :quality => [:style, :stats]
 
 task :default => [:test, :quality]
 

--- a/kitchen-vagrant.gemspec
+++ b/kitchen-vagrant.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "github_changelog_generator", "1.11.3"
 
   gem.add_development_dependency "chefstyle"
-  gem.add_development_dependency "cane", "3.0.0"
 end


### PR DESCRIPTION
chefstyle is where style rules have been defined, so remove cane. If complexity analysis is desired in the future, it can be reenabled in a project-specific config for chefstyle (rubocop).

![don't need cane](https://user-images.githubusercontent.com/517302/28588415-7de03a2e-7148-11e7-84bc-05bc756f3522.gif)
