### PR TITLE
Add support for USB devices under VirtualBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,44 @@ Please read [createhd](https://www.virtualbox.org/manual/ch08.html#vboxmanage-cr
 and [storageattach](https://www.virtualbox.org/manual/ch08.html#vboxmanage-storageattach)
 for additional information on these options.
 
+
+
+
+#### <a name="config-customize-virtualbox-usb"></a> VirtualBox USB devices
+
+Adding the `usb`, `usbehci`, and `usbfilter` keys in `customize` allows for attachment
+to host USB devices in VirtualBox. Note that this requires installing the
+[VirtualBox Extension Pack](https://www.virtualbox.org/wiki/Downloads) on the host.
+
+
+```yaml
+driver:
+  customize:
+    usb: "on"
+    usbehci: "on"
+    usbfilter:
+      name: "YubiKey"
+      vendorid: "0x1050"
+      productid: "0x0120"
+```
+
+will generate a Vagrantfile configuration similar to:
+
+```ruby
+Vagrant.configure("2") do |config|
+  # ...
+
+  config.vm.provider :virtualbox do |virtualbox|
+    virtualbox.customize ["modifyvm", :id, "--usb", "on"]
+    virtualbox.customize ["modifyvm", :id, "--usbehci", "on"]
+    virtualbox.customize ["usbfilter", "add", 0, "--target", :id, "--name", "YubiKey", "--vendorid", "0x1050", "--productid", "0x0120"]
+end
+end
+```
+
+Please read [usbfilter](https://www.virtualbox.org/manual/ch08.html#idm5512)
+for additional information on these options.
+
 ### <a name="config-guest"></a> guest
 
 **Note:** It should largely be the responsibility of the underlying Vagrant

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -170,6 +170,17 @@ Vagrant.configure("2") do |c|
            ids << "\"#{id}\""
          end %>
     p.customize ["modifyvm", :id, "--cpuidset", <%= ids.join(', ') %>]
+    <% elsif key == :usbfilter %>
+      <% options = [] %>
+      <% value.each do |usbfilter_option_key, usbfilter_option_value|
+           options << "\"--#{usbfilter_option_key}\""
+           if usbfilter_option_value.instance_of? Fixnum
+             options << usbfilter_option_value
+           else
+             options << "\"#{usbfilter_option_value}\""
+           end
+         end %>
+    p.customize ["usbfilter", "add", 0, "--target", :id, <%= options.join(', ') %>]
     <% else %>
     p.customize ["modifyvm", :id, "--<%= key %>", "<%= value %>"]
     <% end %>


### PR DESCRIPTION
Add options to allow kitchen to generate a Vagrantfile with the appropriate configuration to pass USB devices through from the host to a VirtualBox VM