### PR TITLE
shorten the directory name for vagrant_root

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -495,7 +495,7 @@ module Kitchen
         if !@vagrant_root && !instance.nil?
           @vagrant_root = File.join(
             config[:kitchen_root], %w{.kitchen kitchen-vagrant},
-            "kitchen-#{File.basename(config[:kitchen_root])}-#{instance.name}"
+            "#{instance.name}"
           )
         end
         @vagrant_root

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -300,7 +300,7 @@ describe Kitchen::Driver::Vagrant do
       config[:pre_create_command] = "{{vagrant_root}}/candy"
 
       expect(driver[:pre_create_command]).to eq(
-        "/kroot/.kitchen/kitchen-vagrant/kitchen-kroot-suitey-fooos-99/candy"
+        "/kroot/.kitchen/kitchen-vagrant/suitey-fooos-99/candy"
       )
     end
 
@@ -613,8 +613,7 @@ describe Kitchen::Driver::Vagrant do
 
     let(:vagrant_root) do
       File.join(%W{
-        #{@dir} .kitchen kitchen-vagrant
-        kitchen-#{File.basename(@dir)}-suitey-fooos-99
+        #{@dir} .kitchen kitchen-vagrant suitey-fooos-99
       })
     end
 
@@ -845,8 +844,7 @@ describe Kitchen::Driver::Vagrant do
 
     let(:vagrant_root) do
       File.join(%W{
-        #{@dir} .kitchen kitchen-vagrant
-        kitchen-#{File.basename(@dir)}-suitey-fooos-99
+        #{@dir} .kitchen kitchen-vagrant suitey-fooos-99
       })
     end
 
@@ -935,8 +933,7 @@ describe Kitchen::Driver::Vagrant do
 
     let(:vagrant_root) do
       File.join(%W{
-        #{@dir} .kitchen kitchen-vagrant
-        kitchen-#{File.basename(@dir)}-suitey-fooos-99
+        #{@dir} .kitchen kitchen-vagrant suitey-fooos-99
       })
     end
 


### PR DESCRIPTION
This omits "kitchen-#{something}" from the vagrant root directories that will appear under .kitchen/kitchen-vagrant. 

[Windows users will run into a path length limit of 260 characters.](https://github.com/test-kitchen/kitchen-vagrant/issues/210) We have been repeating in the directory structure "kitchen-" and the basename of kitchen-root--the directory that contains the .kitchen.yml which most of the time works out to be the name of the cookbook being tested. This made for meaningful if verbose names for virtual machines so as to correlate a machine running in a Vagrant-supported hypervisor to a test-kitchen config.

The inclusion of this string was _not_ for any unique identifier to avoid naming collusions within the hypervisor. This change should be safe for an upgrade for kitchens that have running instances prior to upgrade. The state file for a machine that was successfully created will have recorded the vagrant_root path used at creation time. This will allow kitchen commands to continue to operate on the running instances.

Fixes #210 