### PR TITLE
revert parallelism for Virtualbox

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -378,14 +378,6 @@ module Kitchen
       # @see Kitchen::ShellOut.run_command
       # @api private
       def run(cmd, options = {})
-        if vagrant_root && config[:provider] == "virtualbox"
-          require "digest"
-          options[:environment] = {} if options[:environment].nil?
-          options[:environment]["VBOX_IPC_SOCKETID"] =
-            Digest::SHA256.hexdigest(vagrant_root)
-          options[:environment]["VBOX_USER_HOME"] = vagrant_root
-          debug("Accessing isolated VirtualBox environment in #{vagrant_root}")
-        end
         cmd = "echo #{cmd}" if config[:dry_run]
         run_command(cmd, { :cwd => vagrant_root }.merge(options))
       end
@@ -448,11 +440,6 @@ module Kitchen
       #
       # @api private
       def run_pre_create_command
-        if vagrant_root && config[:provider] == "virtualbox"
-          run("vboxmanage setproperty machinefolder #{vagrant_root}",
-            :cwd => config[:kitchen_root])
-          debug("Set VirtualBox machinefolder to #{vagrant_root}")
-        end
         if config[:pre_create_command]
           run(config[:pre_create_command], :cwd => config[:kitchen_root])
         end

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -95,7 +95,7 @@ module Kitchen
 
       default_config :cachier, nil
 
-      # no_parallel_for :create, :destroy
+      no_parallel_for :create, :destroy
 
       # Creates a Vagrant VM instance.
       #

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -95,9 +95,7 @@ module Kitchen
 
       default_config :cachier, nil
 
-      # disable parallel create/destroy on Windows hosts because it exacerbates an existing
-      # path length problem
-      no_parallel_for :create, :destroy if RbConfig::CONFIG["host_os"] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+      # no_parallel_for :create, :destroy
 
       # Creates a Vagrant VM instance.
       #
@@ -380,7 +378,7 @@ module Kitchen
       # @see Kitchen::ShellOut.run_command
       # @api private
       def run(cmd, options = {})
-        if !windows_host? && vagrant_root && config[:provider] == "virtualbox"
+        if vagrant_root && config[:provider] == "virtualbox"
           require "digest"
           options[:environment] = {} if options[:environment].nil?
           options[:environment]["VBOX_IPC_SOCKETID"] =
@@ -450,7 +448,7 @@ module Kitchen
       #
       # @api private
       def run_pre_create_command
-        if !windows_host? && vagrant_root && config[:provider] == "virtualbox"
+        if vagrant_root && config[:provider] == "virtualbox"
           run("vboxmanage setproperty machinefolder #{vagrant_root}",
             :cwd => config[:kitchen_root])
           debug("Set VirtualBox machinefolder to #{vagrant_root}")
@@ -566,7 +564,7 @@ module Kitchen
       #
       # @api private
       def windows_host?
-        RbConfig::CONFIG["host_os"] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+        RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
       end
 
       # @return [true,false] whether or not the vagrant-winrm plugin is


### PR DESCRIPTION
This change exacerbated an existing path-too-long problem in Windows [#210] and introduced a few new undesired behaviors as default. (#322, kitchen VMs running entirely disconnected from the Virtualbox manager, and `gui: true` no longer working.)

Reverting in favor of working a future PR for Virtualbox parallelism as optional. (Which is tricky given that we'll need to tinker with `@serial_actions` without using `no_parallel_for`.)