### PR TITLE
For WinRM options, only treat strings as strings. 

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -68,7 +68,11 @@ Vagrant.configure("2") do |c|
 <% end %>
 <% if config[:winrm] %>
   <% config[:winrm].each do |key, value| %>
-    c.winrm.<%= key %> = "<%= value %>"
+    <% if value.is_a? String %>
+      c.winrm.<%= key %> = "<%= value%>"
+    <% else  %>
+      c.winrm.<%= key %> = <%= value%>
+    <% end  %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
This fix tries to differentiate strings from non-strings when using kitchen-vagrant & WinRM. It likely addresses https://github.com/test-kitchen/kitchen-vagrant/issues/327 but also an issue I observed when using `retry_delay` and `retry_limit`.

I believe with https://github.com/WinRb/WinRM/commit/a4ab853b04c04b8cf38ed0565fdf01290040f89e in WinRM with switching from `FixNum` to `Integer`, certain features, notably `retry_delay` and `retry_limit`, no longer work when passed in Test Kitchen. This is likely caused by https://github.com/test-kitchen/kitchen-vagrant/pull/306 will always treat set configuration for WinRM as a string. 


First observed when using Vagrant 2.0.0 (which includes 2.2.3 of https://github.com/WinRb/WinRM and Ruby 2.4.0) and latest stable Chef DK (2.3.4).

```
       /opt/vagrant/embedded/gems/gems/winrm-2.2.3/lib/winrm/connection_opts.rb:87:in `validate_integer': retry_delay must be a Integer (RuntimeError)
       	from /opt/vagrant/embedded/gems/gems/winrm-2.2.3/lib/winrm/connection_opts.rb:79:in `validate_data_types'
       	from /opt/vagrant/embedded/gems/gems/winrm-2.2.3/lib/winrm/connection_opts.rb:62:in `validate'
       	from /opt/vagrant/embedded/gems/gems/winrm-2.2.3/lib/winrm/connection_opts.rb:33:in `create_with_defaults'
       	from /opt/vagrant/embedded/gems/gems/winrm-2.2.3/lib/winrm/connection.rb:66:in `configure_connection_opts'
       	from /opt/vagrant/embedded/gems/gems/winrm-2.2.3/lib/winrm/connection.rb:29:in `initialize'
       	from /opt/vagrant/embedded/gems/gems/vagrant-2.0.0/plugins/communicators/winrm/shell.rb:186:in `new'
       	from /opt/vagrant/embedded/gems/gems/vagrant-2.0.0/plugins/communicators/winrm/shell.rb:186:in `new_connection'
       	from /opt/vagrant/embedded/gems/gems/vagrant-2.0.0/plugins/communicators/winrm/shell.rb:192:in `connection'
       	from /opt/vagrant/embedded/gems/gems/vagrant-2.0.0/plugins/communicators/winrm/shell.rb:66:in `cmd'
       	from /opt/vagrant/embedded/gems/gems/vagrant-2.0.0/plugins/communicators/winrm/communicator.rb:107:in `block in ready?'
```
