### PR TITLE
virtualbox: Allow to use storagectl in customize section

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ and [VMware][vagrant_config_vmware] for more details.
 Adding the `createhd` and `storageattach` keys in `customize` allows for creation
 of additional disks in VirtualBox. Full paths must be used as required by VirtualBox.
 
+Adding the `storagectl` key in `customize` allows for creation or customization of
+disks controller in Virtualbox.
+
 *NOTE*: IDE Controller based drives always show up in the boot order first, regardless of if they
 are [bootable][vbox_ide_boot].
 
@@ -282,6 +285,9 @@ driver:
         size: 1024
       - filename: /tmp/disk2.vmdk
         size: 2048
+    storagectl:
+      - name: IDE Controller
+        portcount: 4
     storageattach:
       - storagectl: IDE Controller
         port: 1
@@ -303,13 +309,15 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :virtualbox do |virtualbox|
     virtualbox.customize ["createhd", "--filename", "./tmp/disk1.vmdk", "--size", 1024]
+    virtualbox.customize ["storagectl", :id, "--name", "IDE Controller", "--portcount", 4]
     virtualbox.customize ["storageattach", :id, "--storagectl", "IDE Controller", "--port", "1", "--device", 0, "--type", "hdd", "--medium", "./tmp/disk1.vmdk"]
   end
 end
 ```
 
 Please read [createhd](https://www.virtualbox.org/manual/ch08.html#vboxmanage-createvdi)
-and [storageattach](https://www.virtualbox.org/manual/ch08.html#vboxmanage-storageattach)
+, [storageattach](https://www.virtualbox.org/manual/ch08.html#vboxmanage-storageattach)
+and [storagectl](https://www.virtualbox.org/manual/ch08.html#vboxmanage-storagectl)
 for additional information on these options.
 
 ### <a name="config-guest"></a> guest

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1377,6 +1377,48 @@ describe Kitchen::Driver::Vagrant do
         RUBY
       end
 
+      it "adds lines for single storagectl in :customize" do
+        config[:customize] = {
+          :storagectl => {
+            :name => "Custom SATA Controller",
+            :add => "sata",
+            :controller => "IntelAHCI",
+            :portcount => 4,
+          },
+        }
+        cmd
+
+        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+          c.vm.provider :virtualbox do |p|
+            p.customize ["storagectl", :id, "--name", "Custom SATA Controller", "--add", "sata", "--controller", "IntelAHCI", "--portcount", 4]
+          end
+        RUBY
+      end
+
+      it "adds lines for multiple storagectl in :customize" do
+        config[:customize] = {
+          :storagectl => [
+            {
+              :name => "Custom SATA Controller",
+              :add => "sata",
+              :controller => "IntelAHCI",
+            },
+            {
+              :name => "Custom SATA Controller",
+              :portcount => 4,
+            },
+          ],
+        }
+        cmd
+
+        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+          c.vm.provider :virtualbox do |p|
+            p.customize ["storagectl", :id, "--name", "Custom SATA Controller", "--add", "sata", "--controller", "IntelAHCI"]
+            p.customize ["storagectl", :id, "--name", "Custom SATA Controller", "--portcount", 4]
+          end
+        RUBY
+      end
+
       it "adds lines for single storageattach in :customize" do
         config[:customize] = {
           :storageattach => {

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -160,19 +160,19 @@ Vagrant.configure("2") do |c|
       <% value.each do |item| %>
     p.customize ["createhd", "--filename", "<%= item[:filename] %>", "--size", <%= item[:size] %>]
       <% end %>
-    <% elsif key == :storageattach %>
+    <% elsif key == :storageattach || key == :storagectl %>
       <% value = [value] unless value.instance_of?(Array) %>
       <% value.each do |item| %>
         <% options = [] %>
-        <% item.each do |storageattach_option_key, storageattach_option_value|
-             options << "\"--#{storageattach_option_key}\""
-             if storageattach_option_value.instance_of? Fixnum
-               options << storageattach_option_value
+        <% item.each do |storage_option_key, storage_option_value|
+             options << "\"--#{storage_option_key}\""
+             if storage_option_value.instance_of? Fixnum
+               options << storage_option_value
              else
-               options << "\"#{storageattach_option_value}\""
+               options << "\"#{storage_option_value}\""
              end
            end %>
-    p.customize ["storageattach", :id, <%= options.join(', ') %>]
+    p.customize ["<%= key.to_s %>", :id, <%= options.join(', ') %>]
     <% end %>
     <% elsif key == :cpuidset %>
       <% ids = [] %>


### PR DESCRIPTION
This PR allows to use storagectl in customize section.

This enables various possibilites, such as changing the portcount of a disk controller to be able to attach more disks to it, or create new disk controllers.