### PR TITLE
Hyper-V: Ensure default switch name is always wrapped in quotes

### DIFF
--- a/kitchen-vagrant.gemspec
+++ b/kitchen-vagrant.gemspec
@@ -7,7 +7,7 @@ require "English"
 Gem::Specification.new do |gem|
   gem.name          = "kitchen-vagrant"
   gem.version       = Kitchen::Driver::VAGRANT_VERSION
-  gem.license       = "Apache 2.0"
+  gem.license       = "Apache-2.0"
   gem.authors       = ["Fletcher Nichol"]
   gem.email         = ["fnichol@nichol.ca"]
   gem.description   = "Kitchen::Driver::Vagrant - A Vagrant Driver for Test Kitchen."

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -354,7 +354,7 @@ module Kitchen
         if config[:provider] == "hyperv" && config[:network].empty?
           config[:network].push([
             "public_network",
-            "bridge: #{hyperv_switch}",
+            "bridge: \"#{hyperv_switch}\"",
             ])
         end
       end


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

On a Windows 10 (build 16299) machine, the name of the default Hyper-V switch is `Default Switch`. If the switch is specified in the .kitchen.yml as per the documentation (see below example) then there is no issue with the generated Vagrantfile:

```
  network:
  - ["public_network", bridge: "Default Switch"]
```

However, when the default configuration is used without specifying the above, the following entry is generated in the Vagrantfile:

```
c.vm.network(:public_network, bridge: Default Switch)
```

In turn this leads to Vagrant not being able to validate the file correctly, returning the following error:

```
Vagrantfile:6: syntax error, unexpected tCONSTANT, expecting keyword_do or '{' or '('
       etwork, bridge: Default Switch)
                              ^
Vagrantfile:15: syntax error, unexpected keyword_end, expecting end-of-input
```

This PR ensures that any default switch name returned from the system is wrapped in quotes, generating a valid Vagrantfile.