### PR TITLE
VagrantFile template: use Integer instead of Fixnum (Ruby 2.4.0 compat)

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -170,7 +170,7 @@ Vagrant.configure("2") do |c|
         <% options = [] %>
         <% item.each do |storage_option_key, storage_option_value|
              options << "\"--#{storage_option_key}\""
-             if storage_option_value.instance_of? Fixnum
+             if storage_option_value.instance_of? Integer
                options << storage_option_value
              else
                options << "\"#{storage_option_value}\""


### PR DESCRIPTION
`Fixnum` and `Bignum` are deprecated as of Ruby 2.4.0 and should be replaced by `Integer`