### PR TITLE
Fixing #349 - allow bento/hardenedbsd

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -234,7 +234,7 @@ module Kitchen
       #   box
       # @api private
       def bento_box?(name)
-        name =~ /^(centos|debian|fedora|freebsd|opensuse|ubuntu|oracle)-/
+        name =~ /^(centos|debian|fedora|freebsd|opensuse|ubuntu|oracle|hardenedbsd)-/
       end
 
       # Returns whether or not the we expect the box to work with shared folders

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -161,7 +161,7 @@ describe Kitchen::Driver::Vagrant do
       ]
     end
 
-    %w{centos debian fedora opensuse ubuntu oracle freebsd}.each do |name|
+    %w{centos debian fedora opensuse ubuntu oracle freebsd hardenedbsd}.each do |name|
 
       context "for known bento platform names starting with #{name}" do
 


### PR DESCRIPTION
Fix #349 - we'll grab hardenedbsd-11 from the bento org now

Signed-off-by: Seth Thomas <sthomas@chef.io>