### PR TITLE
Fix #346 - cleanup cache enabling

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -88,9 +88,7 @@ module Kitchen
         driver.windows_os? ? nil : "#{driver.instance.name}.vagrantup.com"
       end
 
-      default_config(:cache_directory) do |driver|
-        driver.windows_os? ? "/omnibus/cache" : "/tmp/omnibus/cache"
-      end
+      default_config :cache_directory, false
 
       default_config :kitchen_cache_directory,
         File.expand_path("~/.kitchen/cache")
@@ -202,8 +200,10 @@ module Kitchen
       # and share a local folder to that directory so that we don't pull them
       # down every single time
       def cache_directory
-        if enable_cache?
+        if config[:cache_directory]
           config[:cache_directory]
+        elsif safe_share?(config[:box])
+          "/tmp/omnibus/cache"
         else
           false
         end
@@ -245,15 +245,6 @@ module Kitchen
       def safe_share?(box)
         return false if config[:provider] =~ /(hyperv|libvirt)/
         box =~ /^bento\/(centos|debian|fedora|opensuse|ubuntu|oracle)-/
-      end
-
-      # Return true if we found the criteria to enable the cache_directory
-      # functionality
-      def enable_cache?
-        return false unless config[:cache_directory]
-        return true if safe_share?(config[:box])
-        # Otherwise
-        false
       end
 
       # Renders and writes out a Vagrantfile dedicated to this instance.


### PR DESCRIPTION
This fixes #346 but also radically simplifies the cache enabling code.

- default is now `false`
- no reason to calculate windows vs linux path as we only ever enable automatically for non-windows
- eliminate `enable_cache?` method, this wasn't really needed and made the logic more confusing
- if `cache_directory` is set by the user, we honor that first

I don't see any downsides to this one but given it's changing defaults would like to make sure I haven't missed something.

Signed-off-by: Seth Thomas <sthomas@chef.io>