### PR TITLE
Fix #365 - add name for virtualbox instances

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1266,6 +1266,16 @@ describe Kitchen::Driver::Vagrant do
 
       before { config[:provider] = "virtualbox" }
 
+      it "sets :name for virtualbox GUI" do
+        cmd
+
+        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+          c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+          end
+        RUBY
+      end
+
       it "adds a line for each element in :customize" do
         config[:customize] = {
           :a_key => "some value",
@@ -1275,6 +1285,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
             p.customize ["modifyvm", :id, "--a_key", "some value"]
             p.customize ["modifyvm", :id, "--something", "else"]
           end
@@ -1294,6 +1305,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
             p.gui = false
           end
         RUBY
@@ -1305,6 +1317,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
             p.gui = true
           end
         RUBY
@@ -1324,6 +1337,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
             p.linked_clone = false
           end
         RUBY
@@ -1335,6 +1349,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
             p.linked_clone = true
           end
         RUBY
@@ -1351,6 +1366,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
             p.customize ["createhd", "--filename", "./d1.vmdk", "--size", 10240]
           end
         RUBY
@@ -1373,6 +1389,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
             p.customize ["createhd", "--filename", "./d1.vmdk", "--size", 10240]
             p.customize ["createhd", "--filename", "./d2.vmdk", "--size", 20480]
           end
@@ -1392,6 +1409,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
             p.customize ["storagectl", :id, "--name", "Custom SATA Controller", "--add", "sata", "--controller", "IntelAHCI", "--portcount", 4]
           end
         RUBY
@@ -1415,6 +1433,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
             p.customize ["storagectl", :id, "--name", "Custom SATA Controller", "--add", "sata", "--controller", "IntelAHCI"]
             p.customize ["storagectl", :id, "--name", "Custom SATA Controller", "--portcount", 4]
           end
@@ -1432,6 +1451,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
             p.customize ["storageattach", :id, "--type", "hdd", "--port", 1]
           end
         RUBY
@@ -1460,6 +1480,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
             p.customize ["storageattach", :id, "--storagectl", "SATA Controller", "--port", 1, "--device", 0, "--type", "hdd", "--medium", "./d1.vmdk"]
             p.customize ["storageattach", :id, "--storagectl", "SATA Controller", "--port", 1, "--device", 1, "--type", "hdd", "--medium", "./d2.vmdk"]
           end
@@ -1474,6 +1495,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
             p.customize ["modifyvm", :id, "--cpuidset", "00000001", "00000002"]
           end
         RUBY

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -91,6 +91,11 @@ Vagrant.configure("2") do |c|
 
   c.vm.provider :<%= config[:provider] %> do |p|
 <% case config[:provider]
+   when "virtualbox" %>
+    p.name = "kitchen-<%= File.basename(config[:kitchen_root]) %>-<%= instance.name %>"
+<% end %>
+   
+<% case config[:provider]
    when "virtualbox", /^vmware_/
      if config[:gui] == true || config[:gui] == false %>
     p.gui = <%= config[:gui] %>


### PR DESCRIPTION
Fixes #365 

This adds the `name` parameter for the VirtualBox provider configuration in the generated Vagrantfile. This only affects the UI and restores the old naming convention which make finding the VMs in the UI more convenient.

Signed-off-by: Seth Thomas <sthomas@chef.io>