### PR TITLE
Adding a per-instance generated vmname for Hyper-V

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -107,8 +107,9 @@ Vagrant.configure("2") do |c|
      if config[:linked_clone] == true || config[:linked_clone] == false %>
     p.linked_clone = <%= config[:linked_clone] %>
 <%   end
-   when "hyperv"
-     if config[:linked_clone] == true || config[:linked_clone] == false %>
+   when "hyperv" %>
+    p.vmname = "kitchen-<%= File.basename(config[:kitchen_root]) %>-<%= instance.name %>"
+<%   if config[:linked_clone] == true || config[:linked_clone] == false %>
     p.differencing_disk = <%= config[:linked_clone] %>
 <%   end
    end %>


### PR DESCRIPTION
Fixes #367

This PR allows a VM instance created by kitchen-vagrant and the Hyper-V provider to be identified by its instance name.  This makes it easier to identify the running VM when looking at the Hyper-V running configuration (either via UI or PowerShell).

The actual hostname (Linux) or NetBIOS name of the machine (if Windows) is not affected by this change, it only affects the display name in Hyper-V manager.

Given a base folder name of *hypervtest*, a *default* suite and a platform named *windows2012r2*, the generated name is as follows: `kitchen-hypervtest-default-windows2012r2`

![image](https://user-images.githubusercontent.com/6384654/44033307-e3fdaa3e-9f01-11e8-86c8-0851a36057df.png)

Signed-off-by: Stuart Preston <stuart@chef.io>