### PR TITLE
Vagrantfile Template: Hyper-v Differencing_disk deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Vagrant.configure("2") do |config|
   # ...
 
   c.vm.provider :hyperv do |p|
-    p.differencing_disk = true
+    p.linked_clone = true
   end
 end
 ```

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -110,7 +110,7 @@ Vagrant.configure("2") do |c|
    when "hyperv" %>
     p.vmname = "kitchen-<%= File.basename(config[:kitchen_root]) %>-<%= instance.name %>"
 <%   if config[:linked_clone] == true || config[:linked_clone] == false %>
-    p.differencing_disk = <%= config[:linked_clone] %>
+    p.linked_clone = <%= config[:linked_clone] %>
 <%   end
    end %>
 


### PR DESCRIPTION
With the deprecation of the differencing_disk property.
It's need to be updated to linked_clone.