### PR TITLE
Newest vagrant no long requires vagrant-winrm plugin

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -556,11 +556,13 @@ module Kitchen
             " Please upgrade to version 1.6 or higher from #{WEBSITE}."
         end
 
-        if !winrm_plugin_installed?
-          raise UserError, "WinRM Transport requires the vagrant-winrm " \
-            "Vagrant plugin to properly communicate with this Vagrant VM. " \
-            "Please install this plugin with: " \
-            "`vagrant plugin install vagrant-winrm' and try again."
+        if Gem::Version.new(vagrant_version) < Gem::Version.new("2.2.0") && !winrm_plugin_installed?
+          raise UserError, "Vagrant version #{vagrant_version} requires the " \
+            "vagrant-winrm plugin to properly communicate with this Vagrant VM " \
+            "over WinRM Transport. Please install this plugin with: " \
+            "`vagrant plugin install vagrant-winrm' and try again." \
+            "Alternatively upgrade to Vagrant >= 2.2.0 which does not " \
+            "require the vagrant-winrm plugin."
         end
       end
 


### PR DESCRIPTION
1. ~This is pending on https://github.com/hashicorp/vagrant/pull/10263 getting merged and released~
1. We need some logic for what to do when vagrant is between `2.1.5` and `2.1.7`. Between those versions vagrant does not require `vagrant-winrm` but it will not work because the code from https://github.com/hashicorp/vagrant/pull/10263 is not in there

Signed-off-by: tyler-ball <tball@chef.io>