### PR TITLE
Added WSL support

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -92,8 +92,11 @@ module Kitchen
         driver.windows_os? ? "/omnibus/cache" : "/tmp/omnibus/cache"
       end
 
+      # for use with vagrant on WSL
+      user_home = ENV["VAGRANT_WSL_WINDOWS_ACCESS_USER_HOME_PATH"].nil? ? "~" : ENV["VAGRANT_WSL_WINDOWS_ACCESS_USER_HOME_PATH"]
+
       default_config :kitchen_cache_directory,
-        File.expand_path("~/.kitchen/cache")
+        File.expand_path("#{user_home}/.kitchen/cache")
 
       default_config :cachier, nil
 


### PR DESCRIPTION
- Updated vagrant.rb to read from `VAGRANT_WSL_WINDOWS_ACCESS_USER_HOME_PATH` if set
- [More information](https://www.vagrantup.com/docs/other/wsl.html#vagrant_wsl_windows_access_user_home_path)

### Disclaimer
I have no experience with ruby/vagrant/chef