### PR TITLE
Restores vm name uniqueness.

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1269,9 +1269,9 @@ describe Kitchen::Driver::Vagrant do
       it "sets :name for virtualbox GUI" do
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.customize ["modifyvm", :id, "--audio", "none"]
           end
         RUBY
@@ -1300,9 +1300,9 @@ describe Kitchen::Driver::Vagrant do
         }
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.customize ["modifyvm", :id, "--audio", "none"]
             p.customize ["modifyvm", :id, "--a_key", "some value"]
             p.customize ["modifyvm", :id, "--something", "else"]
@@ -1321,9 +1321,9 @@ describe Kitchen::Driver::Vagrant do
         config[:gui] = false
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.gui = false
             p.customize ["modifyvm", :id, "--audio", "none"]
           end
@@ -1334,9 +1334,9 @@ describe Kitchen::Driver::Vagrant do
         config[:gui] = true
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.gui = true
             p.customize ["modifyvm", :id, "--audio", "none"]
           end
@@ -1355,9 +1355,9 @@ describe Kitchen::Driver::Vagrant do
         config[:linked_clone] = false
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.linked_clone = false
             p.customize ["modifyvm", :id, "--audio", "none"]
           end
@@ -1368,9 +1368,9 @@ describe Kitchen::Driver::Vagrant do
         config[:linked_clone] = true
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.linked_clone = true
             p.customize ["modifyvm", :id, "--audio", "none"]
           end
@@ -1386,9 +1386,9 @@ describe Kitchen::Driver::Vagrant do
         }
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.customize ["modifyvm", :id, "--audio", "none"]
             p.customize ["createhd", "--filename", "./d1.vmdk", "--size", 10240]
           end
@@ -1410,9 +1410,9 @@ describe Kitchen::Driver::Vagrant do
         }
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.customize ["modifyvm", :id, "--audio", "none"]
             p.customize ["createhd", "--filename", "./d1.vmdk", "--size", 10240]
             p.customize ["createhd", "--filename", "./d2.vmdk", "--size", 20480]
@@ -1431,9 +1431,9 @@ describe Kitchen::Driver::Vagrant do
         }
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.customize ["modifyvm", :id, "--audio", "none"]
             p.customize ["storagectl", :id, "--name", "Custom SATA Controller", "--add", "sata", "--controller", "IntelAHCI", "--portcount", 4]
           end
@@ -1456,9 +1456,9 @@ describe Kitchen::Driver::Vagrant do
         }
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.customize ["modifyvm", :id, "--audio", "none"]
             p.customize ["storagectl", :id, "--name", "Custom SATA Controller", "--add", "sata", "--controller", "IntelAHCI"]
             p.customize ["storagectl", :id, "--name", "Custom SATA Controller", "--portcount", 4]
@@ -1475,9 +1475,9 @@ describe Kitchen::Driver::Vagrant do
         }
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.customize ["modifyvm", :id, "--audio", "none"]
             p.customize ["storageattach", :id, "--type", "hdd", "--port", 1]
           end
@@ -1505,9 +1505,9 @@ describe Kitchen::Driver::Vagrant do
         }
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.customize ["modifyvm", :id, "--audio", "none"]
             p.customize ["storageattach", :id, "--storagectl", "SATA Controller", "--port", 1, "--device", 0, "--type", "hdd", "--medium", "./d1.vmdk"]
             p.customize ["storageattach", :id, "--storagectl", "SATA Controller", "--port", 1, "--device", 1, "--type", "hdd", "--medium", "./d2.vmdk"]
@@ -1521,9 +1521,9 @@ describe Kitchen::Driver::Vagrant do
         }
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99"
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.customize ["modifyvm", :id, "--audio", "none"]
             p.customize ["modifyvm", :id, "--cpuidset", "00000001", "00000002"]
           end

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -92,7 +92,7 @@ Vagrant.configure("2") do |c|
   c.vm.provider :<%= config[:provider] %> do |p|
 <% case config[:provider]
    when "virtualbox" %>
-    p.name = "kitchen-<%= File.basename(config[:kitchen_root]) %>-<%= instance.name %>"
+    p.name = "kitchen-<%= File.basename(config[:kitchen_root]) %>-<%= instance.name %>-<%= SecureRandom.uuid %>"
 <% end %>
 
 <% case config[:provider]
@@ -108,7 +108,7 @@ Vagrant.configure("2") do |c|
     p.linked_clone = <%= config[:linked_clone] %>
 <%   end
    when "hyperv" %>
-    p.vmname = "kitchen-<%= File.basename(config[:kitchen_root]) %>-<%= instance.name %>"
+    p.vmname = "kitchen-<%= File.basename(config[:kitchen_root]) %>-<%= instance.name %>-<%= SecureRandom.uuid %>"
 <%   if config[:linked_clone] == true || config[:linked_clone] == false %>
     p.linked_clone = <%= config[:linked_clone] %>
 <%   end


### PR DESCRIPTION
Fixes bug introduced by #366. By specifying a name in the Vagrantfile,
we lose uniqueness added by the [Vagrant SetName
class](https://github.com/hashicorp/vagrant/blob/85acf0cac724ef4bfda593a66e0c17f7e4110da0/plugins/providers/virtualbox/action/set_name.rb#L29).
This PR restores uniqueness.

Closes #376.