### PR TITLE
Hyper-v Name Length fix

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -108,7 +108,7 @@ Vagrant.configure("2") do |c|
     p.linked_clone = <%= config[:linked_clone] %>
 <%   end
    when "hyperv" %>
-    p.vmname = "kitchen-<%= File.basename(config[:kitchen_root]) %>-<%= instance.name %>-<%= SecureRandom.uuid %>"
+    p.vmname = "<%="kitchen-#{File.basename(config[:kitchen_root])}-#{instance.name}-#{SecureRandom.uuid}"[0..99].delete_suffix('-') %>"
 <%   if config[:linked_clone] == true || config[:linked_clone] == false %>
     p.linked_clone = <%= config[:linked_clone] %>
 <%   end


### PR DESCRIPTION
## Description
As part of https://github.com/test-kitchen/kitchen-vagrant/commit/b018a077b93cc343f29c43e9eec2366f38eefe61 to introduce unique names a uuid was added to the generated vagrantfile. This causes problems with hyper-v which relies on names being 100 characters or less otherwise it throws an exception.

This commit takes the current naming system and substrings it to fit within this character limit. It may be a better idea to use time ticks as these would end up with us substringing less due to their shorter nature (the UUID is a third of the allowed length by itself)

## Kitchen-Vagrant Version
1.5.2

## Test-Kitchen Version
2.2.5

## Vagrant Version
2.2.5

## Host Operating System
Windows 10

## Issues Resolved:
#403 