### PR TITLE
Release 1.6.0 requiring Ruby 2.3+ and fixing Chefstyle issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ rvm:
 
 bundler_args: --without guard, changelog
 
-sudo: false
-
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
   - ruby-head
 
 bundler_args: --without guard, changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.6.0](https://github.com/test-kitchen/kitchen-vagrant/tree/1.6.0) (2019-08-05)
+[Full Changelog](https://github.com/test-kitchen/kitchen-vagrant/compare/v1.5.2...v1.6.0)
+
+- Don't fail when instance names become too long for Hyper-V [#404](https://github.com/test-kitchen/kitchen-vagrant/pull/404) ([@Xorima](https://github.com/Xorima))
+- Require Ruby 2.3 or later (Ruby < 2.3 are no longer supported Ruby releases)
+
 ## [1.5.2](https://github.com/test-kitchen/kitchen-vagrant/tree/1.5.2) (2019-05-02)
 [Full Changelog](https://github.com/test-kitchen/kitchen-vagrant/compare/v1.5.1...v1.5.2)
 

--- a/Guardfile
+++ b/Guardfile
@@ -17,7 +17,7 @@ group :red_green_refactor, halt_on_fail: true do
   end
 
   guard :rubocop, rubocop_opts do
-    watch(%r{.+\.rb$})
+    watch(/.+\.rb$/)
     watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -26,9 +26,9 @@ task :stats do
 end
 
 desc "Run all quality tasks"
-task quality: [:style, :stats]
+task quality: %i{style stats}
 
-task default: [:test, :quality]
+task default: %i{test quality}
 
 begin
   require "github_changelog_generator/task"

--- a/kitchen-vagrant.gemspec
+++ b/kitchen-vagrant.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(/LICENSE|^lib|^support|^templates/)
   gem.require_paths = ["lib"]
 
+  gem.required_ruby_version = ">= 2.3"
+
   gem.add_dependency "test-kitchen", ">= 1.4", "< 3"
 
   gem.add_development_dependency "countloc", "~> 0.4"

--- a/lib/kitchen/driver/helpers.rb
+++ b/lib/kitchen/driver/helpers.rb
@@ -76,6 +76,7 @@ module Kitchen
         sh.run_command
         debug("Local Command END #{Util.duration(sh.execution_time)}")
         raise "Failed: #{sh.stderr}" if sh.error?
+
         stdout = sanitize_stdout(sh.stdout)
         JSON.parse(stdout) if stdout.length > 2
       end
@@ -91,12 +92,13 @@ module Kitchen
             default_switch_object["Name"].empty?
           raise "Failed to find a default VM Switch."
         end
+
         default_switch_object["Name"]
       end
 
       def hyperv_default_switch_ps
         <<-VMSWITCH
-          Get-DefaultVMSwitch #{ENV['KITCHEN_HYPERV_SWITCH']} | ConvertTo-Json
+          Get-DefaultVMSwitch #{ENV["KITCHEN_HYPERV_SWITCH"]} | ConvertTo-Json
         VMSWITCH
       end
 
@@ -104,6 +106,7 @@ module Kitchen
 
       def ruby_array_to_ps_array(list)
         return "@()" if list.nil? || list.empty?
+
         list.to_s.tr("[]", "()").prepend("@")
       end
     end

--- a/lib/kitchen/driver/vagrant_version.rb
+++ b/lib/kitchen/driver/vagrant_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Vagrant Kitchen driver
-    VAGRANT_VERSION = "1.5.2".freeze
+    VAGRANT_VERSION = "1.6.0".freeze
   end
 end

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -38,8 +38,8 @@ describe Kitchen::Driver::Vagrant do
   let(:lifecycle_hooks) { Kitchen::LifecycleHooks.new({}) }
   let(:transport)     { Kitchen::Transport::Dummy.new }
   let(:state_file)    { double("state_file") }
-  let(:state)         { Hash.new }
-  let(:env)           { Hash.new }
+  let(:state)         { {} }
+  let(:env)           { {} }
 
   let(:driver_object) { Kitchen::Driver::Vagrant.new(config) }
 
@@ -90,7 +90,8 @@ describe Kitchen::Driver::Vagrant do
 
   it "plugin_version is set to Kitchen::Vagrant::VERSION" do
     expect(driver.diagnose_plugin[:version]).to eq(
-      Kitchen::Driver::VAGRANT_VERSION)
+      Kitchen::Driver::VAGRANT_VERSION
+    )
   end
 
   describe "#run_command" do
@@ -101,7 +102,8 @@ describe Kitchen::Driver::Vagrant do
         options = driver.send(
           :run_command,
           "cmd",
-          environment: { "EV1" => "Val1", "EV2" => "Val2" })
+          environment: { "EV1" => "Val1", "EV2" => "Val2" }
+        )
         expect(options[:environment]["EV1"]).to eq("Val1")
         expect(options[:environment]["EV2"]).to eq("Val2")
       end
@@ -111,7 +113,8 @@ describe Kitchen::Driver::Vagrant do
         options = driver.send(
           :run_command,
           "cmd",
-          environment: { "PATH" => path })
+          environment: { "PATH" => path }
+        )
         expect(options[:environment]["PATH"]).to eq(path)
       end
 
@@ -420,14 +423,16 @@ describe Kitchen::Driver::Vagrant do
       config[:vagrantfile_erb] = "/a/Vagrantfile.erb"
 
       expect(driver[:vagrantfile_erb]).to eq(
-        File.expand_path("/a/Vagrantfile.erb"))
+        File.expand_path("/a/Vagrantfile.erb")
+      )
     end
 
     it "expands path for :vagrantfile_erb" do
       config[:vagrantfile_erb] = "Yep.erb"
 
       expect(driver[:vagrantfile_erb]).to eq(
-        File.expand_path("/kroot/Yep.erb"))
+        File.expand_path("/kroot/Yep.erb")
+      )
     end
 
     it "sets :vagrantfiles to an empty array by default" do
@@ -1101,21 +1106,21 @@ describe Kitchen::Driver::Vagrant do
     it "sets vm.box_download_insecure to false
           if :box_download_insecure is false" do
 
-      config[:box_download_insecure] = false
-      cmd
+            config[:box_download_insecure] = false
+            cmd
 
-      expect(
-        vagrantfile).to match(regexify(%{c.vm.box_download_insecure = "false"})
-      )
-    end
+            expect(
+              vagrantfile
+            ).to match(regexify(%{c.vm.box_download_insecure = "false"}))
+          end
 
     it "sets vm.box_download_insecure if :box_download_insecure is set" do
       config[:box_download_insecure] = "um"
       cmd
 
       expect(
-        vagrantfile).to match(regexify(%{c.vm.box_download_insecure = "um"})
-      )
+        vagrantfile
+      ).to match(regexify(%{c.vm.box_download_insecure = "um"}))
     end
 
     it "sets no vm.communicator if missing" do
@@ -1348,7 +1353,8 @@ describe Kitchen::Driver::Vagrant do
         cmd
 
         expect(vagrantfile).to_not match(
-          regexify(%{p.linked_clone = }, :partial))
+          regexify(%{p.linked_clone = }, :partial)
+        )
       end
 
       it "sets :linked_clone to false if set" do
@@ -1570,7 +1576,8 @@ describe Kitchen::Driver::Vagrant do
         cmd
 
         expect(vagrantfile).to_not match(
-          regexify(%{p.linked_clone = }, :partial))
+          regexify(%{p.linked_clone = }, :partial)
+        )
       end
 
       it "sets :linked_clone to false if set" do
@@ -1992,8 +1999,8 @@ describe Kitchen::Driver::Vagrant do
 
       it "builds an array for security group ids in :customize" do
         config[:customize] = {
-          security_group_ids: ["aaaa-bbbb-cccc-dddd",
-                                  "1111-2222-3333-4444"],
+          security_group_ids: %w{aaaa-bbbb-cccc-dddd
+                                  1111-2222-3333-4444},
         }
         cmd
 
@@ -2114,7 +2121,7 @@ describe Kitchen::Driver::Vagrant do
   end
 
   def debug_lines
-    regex = %r{^D, .* : }
+    regex = /^D, .* : /
     logged_output.string.lines
       .select { |l| l =~ regex }.map { |l| l.sub(regex, "") }.join
   end

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -108,7 +108,7 @@ Vagrant.configure("2") do |c|
     p.linked_clone = <%= config[:linked_clone] %>
 <%   end
    when "hyperv" %>
-    p.vmname = "<%="kitchen-#{File.basename(config[:kitchen_root])}-#{instance.name}-#{SecureRandom.uuid}"[0..99].delete_suffix('-') %>"
+    p.vmname = "<%="kitchen-#{File.basename(config[:kitchen_root])}-#{instance.name}-#{SecureRandom.uuid}"[0..99].chomp('-') %>"
 <%   if config[:linked_clone] == true || config[:linked_clone] == false %>
     p.linked_clone = <%= config[:linked_clone] %>
 <%   end


### PR DESCRIPTION
Autocorrect with Chefstyle which uses Ruby 2.3-isms. Add a required ruby version to the gemspec for the first time.