### PR TITLE
Optimize our requires

### DIFF
--- a/lib/kitchen/driver/helpers.rb
+++ b/lib/kitchen/driver/helpers.rb
@@ -15,9 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "mixlib/shellout"
-require "fileutils"
-require "json"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+require "fileutils" unless defined?(FileUtils)
+require "json" unless defined?(JSON)
 
 module Kitchen
   module Driver

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -16,8 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "erb"
-require "fileutils"
+require "erb" unless defined?(Erb)
+require "fileutils" unless defined?(FileUtils)
 require "rubygems/version"
 
 require "kitchen"

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -19,7 +19,7 @@
 require_relative "../../spec_helper"
 
 require "logger"
-require "stringio"
+require "stringio" unless defined?(StringIO)
 
 require "kitchen/driver/vagrant"
 require "kitchen/provisioner/dummy"


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>