### PR TITLE
Use match? when we don't need the match data

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -255,7 +255,7 @@ module Kitchen
       #   shared folders
       # @api private
       def safe_share?(box)
-        return false if config[:provider] =~ /(hyperv|libvirt)/
+        return false if /(hyperv|libvirt)/.match?(config[:provider])
 
         box =~ %r{^bento/(centos|debian|fedora|opensuse|ubuntu|oracle|amazonlinux)-}
       end


### PR DESCRIPTION
This saves us memory by not allocating an object for the match

Signed-off-by: Tim Smith <tsmith@chef.io>