### PR TITLE
Don't fail if active boxes can't be pruned

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -317,7 +317,7 @@ module Kitchen
       def finalize_box_auto_prune!
         return if config[:box_auto_prune].nil?
 
-        config[:box_auto_prune] = "vagrant box prune --name #{config[:box]}"
+        config[:box_auto_prune] = "vagrant box prune --keep-active-boxes --name #{config[:box]}"
       end
 
       # Replaces any `{{vagrant_root}}` tokens in the pre create command.


### PR DESCRIPTION
When we're pruning a box make sure not to fail if there's an active box
preventing the full prune.

Signed-off-by: Tim Smith <tsmith@chef.io>