### PR TITLE
Ignore error if box not found when updating

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -485,7 +485,13 @@ module Kitchen
       # Tell vagrant to update vagrant box to latest version
       def run_box_auto_update
         if config[:box_auto_update]
-          run(config[:box_auto_update])
+          begin
+            run(config[:box_auto_update])
+          rescue Kitchen::ShellOut::ShellCommandFailed => e
+            # If the box has never been downloaded, the update command will fail with this message.
+            # Just ignore it and move on. Re-raise all other errors.
+            raise e unless e.message.match?(/The box '.*' does not exist/m)
+          end
         end
       end
 


### PR DESCRIPTION
When performing a `vagrant box update --box BOXNAME`, the CLI command will exit with code 1 if the named box does not already exist. In our use case, we can ignore that error and happily continue, since our later vagrant up command will download the box if missing. 

I considered explicitly listing boxes rather than ignoring an error, but that would introduce a performance penalty to every run.

## Issues Resolved

Fixes #425 


## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
