### PR TITLE
Fix tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,6 @@ RuboCop::RakeTask.new(:style) do |task|
 end
 
 desc "Run all quality tasks"
-task quality: %i{style stats}
+task quality: %i{style}
 
 task default: %i{test quality}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,3 +30,4 @@ elsif ENV["COVERAGE"]
   end
   SimpleCov.start "gem"
 end
+require "securerandom"


### PR DESCRIPTION
# Description

Fixes the tests by doing two things:

1. requiring `securerandom` in the spec helper, since the Vagrantfile template relies on it during testing. I tried requiring it directly in the template, but that appears to be too late.
2. Deleting a reference to a nonexistent `stats` rake task.

With those two changes in , `bundle exec rake` runs and exits with 0 locally for me.

## Issues Resolved



## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
