### PR TITLE
allows using cached_copy of the chef-client like with bento boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.8.1]
+
+- Enable using the cached chef client on non bento vagrant boxes that have guest additions installed.
+
 ## [1.8.0](https://github.com/test-kitchen/kitchen-vagrant/tree/1.8.0) (2021-02-02)
 
 - Require Ruby 2.5 or later (2.3/2.4 are EOL) ([@tas50](https://github.com/tas50))

--- a/README.md
+++ b/README.md
@@ -544,6 +544,21 @@ driver:
   kitchen_cache_directory: Z:\\custom\\kitchen_cache
 ```
 
+### <a name="use_cached_chef_client"></a> use_cached_chef_client
+
+Will allow you to reuse chef infra clients downloaded during previous kitchen runs from the cache folder on a non bento customized build vagrant box image.
+The `Guest Additions` must be installed in the box image to support shared folder.
+
+The default is `false`
+
+The example:
+
+```yaml
+---
+driver:
+  use_cached_chef_client: true
+```
+
 ### <a name="config-vagrantfile-erb"></a> vagrantfile\_erb
 
 An alternate Vagrantfile ERB template that will be rendered for use by this

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -78,6 +78,8 @@ module Kitchen
 
       default_config :synced_folders, []
 
+      default_config :use_cached_chef_client, false
+
       default_config :vagrant_binary, "vagrant"
 
       default_config :vagrantfile_erb,
@@ -264,7 +266,7 @@ module Kitchen
       def enable_cache?
         return false unless config[:cache_directory]
         return true if safe_share?(config[:box])
-
+        return true if config[:use_cached_chef_client]
         # Otherwise
         false
       end

--- a/lib/kitchen/driver/vagrant_version.rb
+++ b/lib/kitchen/driver/vagrant_version.rb
@@ -20,6 +20,6 @@ module Kitchen
   module Driver
 
     # Version string for Vagrant Kitchen driver
-    VAGRANT_VERSION = "1.8.0".freeze
+    VAGRANT_VERSION = "1.8.1".freeze
   end
 end


### PR DESCRIPTION
# Description

This change would add the ability for people creating their own boxes to use the cached version of the chef client like the bento machines are doing. That saves a lot of time and bandwitdh on slow and offshore connections that need to download the chef client for windows every time they run a test.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
