### PR TITLE
Createhd existing

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1391,12 +1391,12 @@ describe Kitchen::Driver::Vagrant do
         }
         cmd
 
-        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
-          c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
-            p.customize ["modifyvm", :id, "--audio", "none"]
-            p.customize ["createhd", "--filename", "./d1.vmdk", "--size", 10240]
-          end
+        expect(vagrantfile).to include(<<-RUBY.gsub(/^ {8}/, "").chomp)
+          unless File.file?("./d1.vmdk")
+        RUBY
+
+        expect(vagrantfile).to include(<<-RUBY.gsub(/^ {8}/, "").chomp)
+          p.customize ["createhd", "--filename", "./d1.vmdk", "--size", 10240]
         RUBY
       end
 
@@ -1415,13 +1415,20 @@ describe Kitchen::Driver::Vagrant do
         }
         cmd
 
-        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
-          c.vm.provider :virtualbox do |p|
-            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
-            p.customize ["modifyvm", :id, "--audio", "none"]
-            p.customize ["createhd", "--filename", "./d1.vmdk", "--size", 10240]
-            p.customize ["createhd", "--filename", "./d2.vmdk", "--size", 20480]
-          end
+        expect(vagrantfile).to include(<<-RUBY.gsub(/^ {8}/, "").chomp)
+          unless File.file?("./d1.vmdk")
+        RUBY
+
+        expect(vagrantfile).to include(<<-RUBY.gsub(/^ {8}/, "").chomp)
+          p.customize ["createhd", "--filename", "./d1.vmdk", "--size", 10240]
+        RUBY
+
+        expect(vagrantfile).to include(<<-RUBY.gsub(/^ {8}/, "").chomp)
+          unless File.file?("./d2.vmdk")
+        RUBY
+
+        expect(vagrantfile).to include(<<-RUBY.gsub(/^ {8}/, "").chomp)
+          p.customize ["createhd", "--filename", "./d2.vmdk", "--size", 20480]
         RUBY
       end
 

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -173,7 +173,9 @@ Vagrant.configure("2") do |c|
     <% if key == :createhd %>
       <% value = [value] unless value.instance_of?(Array) %>
       <% value.each do |item| %>
-    p.customize ["createhd", "--filename", "<%= item[:filename] %>", "--size", <%= item[:size] %>]
+    unless File.file?("<%= item[:filename] %>")
+      p.customize ["createhd", "--filename", "<%= item[:filename] %>", "--size", <%= item[:size] %>]
+    end
       <% end %>
     <% elsif key == :storageattach || key == :storagectl %>
       <% value = [value] unless value.instance_of?(Array) %>


### PR DESCRIPTION
# Description

This PR attempts to address review comments from https://github.com/test-kitchen/kitchen-vagrant/pull/389 to the extent possible. A note on the unit-test scope- it appears the tests only validate the right composition of `vagrantfile` and not its execution. 

## Issues Resolved

Addresses issue https://github.com/test-kitchen/kitchen-vagrant/issues/387

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
