### PR TITLE
Updated use_cached_chef_client PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.11.0]
+
+- Adds `use_cached_chef_client` option to enable using the cached Chef Infra Client installers on non-Bento Vagrant boxes that have `Guest Additions` installed.
+
 ## [1.10.0](https://github.com/test-kitchen/kitchen-vagrant/tree/1.10.0) (2021-08-25)
 
 - Only create the virtual drive if it doesn't already exist locally

--- a/README.md
+++ b/README.md
@@ -544,6 +544,21 @@ driver:
   kitchen_cache_directory: Z:\\custom\\kitchen_cache
 ```
 
+### <a name="use_cached_chef_client"></a> use_cached_chef_client
+
+Allows for use of Chef Infra Client installers downloaded during previous Test Kitchen runs from the cache folder on a non-Bento customized build Vagrant box image.
+The `Guest Additions` tools must be installed in the box image to support shared folder.
+
+The default is `false`
+
+The example:
+
+```yaml
+---
+driver:
+  use_cached_chef_client: true
+```
+
 ### <a name="config-vagrantfile-erb"></a> vagrantfile\_erb
 
 An alternate Vagrantfile ERB template that will be rendered for use by this

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -78,6 +78,8 @@ module Kitchen
 
       default_config :synced_folders, []
 
+      default_config :use_cached_chef_client, false
+
       default_config :vagrant_binary, "vagrant"
 
       default_config :vagrantfile_erb,
@@ -264,7 +266,7 @@ module Kitchen
       def enable_cache?
         return false unless config[:cache_directory]
         return true if safe_share?(config[:box])
-
+        return true if config[:use_cached_chef_client]
         # Otherwise
         false
       end

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -267,6 +267,7 @@ module Kitchen
         return false unless config[:cache_directory]
         return true if safe_share?(config[:box])
         return true if config[:use_cached_chef_client]
+
         # Otherwise
         false
       end

--- a/lib/kitchen/driver/vagrant_version.rb
+++ b/lib/kitchen/driver/vagrant_version.rb
@@ -20,6 +20,6 @@ module Kitchen
   module Driver
 
     # Version string for Vagrant Kitchen driver
-    VAGRANT_VERSION = "1.10.0".freeze
+    VAGRANT_VERSION = "1.11.0".freeze
   end
 end

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -355,6 +355,12 @@ describe Kitchen::Driver::Vagrant do
       expect(driver[:synced_folders]).to eq([])
     end
 
+    it "sets :synced_folders with the cache_directory when :use_cached_chef_client is `true`" do
+      config[:box] = "some_owner/centos-99"
+      config[:use_cached_chef_client] = true
+      expect(driver[:synced_folders]).to eq([cache_directory_array])
+    end
+
     it "does not set :synced_folders to cache_directory on freebsd systems" do
       allow(platform).to receive(:name).and_return("freebsd-99")
       expect(driver[:synced_folders]).to eq([])


### PR DESCRIPTION
# Description

Rebased and updated version of changes in #453 with original changes by @gaelik still in the merge history.
Description from #453
```
This change would add the ability for people creating their own boxes to use the cached version of the chef client like the bento machines are doing. That saves a lot of time and bandwitdh on slow and offshore connections that need to download the chef client for windows every time they run a test.
```

This update rebases #453 from current upstream `master` and additionally adds spec testing and README wording updates for `use_cached_chef_client` configuration.

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
