### PR TITLE
Use chefstyle linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
---- 
-updates: 
-  - 
+---
+updates:
+  -
     directory: /
     open-pull-requests-limit: 10
     package-ecosystem: bundler
-    schedule: 
+    schedule:
       interval: daily
 version: 2

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -27,4 +27,5 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: bundle exec rake style
+      - uses: r7kamura/rubocop-problem-matchers-action@v1
+      - run: bundle exec chefstyle


### PR DESCRIPTION
Signed-off-by: sachin007jain <sachin.jain@chef.io>

# Description

Using Chefstyle for linting instead of Rubocop

## Issues Resolved

- https://github.com/chef/chef-workstation/issues/2522

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
