### PR TITLE
run specs on ruby 3.1 and remove 2.5 support

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -5,21 +5,21 @@ name: linters
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Run yaml Lint
         uses: actionshub/yamllint@main
   chefstyle:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.6', '2.7', '3.0', '3.1']
     name: Chefstyle on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -5,14 +5,14 @@ name: Unit
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.6', '2.7', '3.0', '3.1']
     name: Unit test on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6

--- a/kitchen-vagrant.gemspec
+++ b/kitchen-vagrant.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(/LICENSE|^lib|^support|^templates/)
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.5"
+  gem.required_ruby_version = ">= 2.6"
 
   gem.add_dependency "test-kitchen", ">= 1.4", "< 4"
 end


### PR DESCRIPTION
# Description
This PR drops ruby 2.5 support and adds 3.1 support

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
