### PR TITLE
Ruby 3 compatibility for network configuration

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1241,8 +1241,8 @@ describe Kitchen::Driver::Vagrant do
       cmd
 
       expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {6}/, "").chomp))
-        c.vm.network(:forwarded_port, {:guest=>80, :host=>8080})
-        c.vm.network(:private_network, {:ip=>"192.168.33.33"})
+        c.vm.network(:forwarded_port, :guest=>80, :host=>8080)
+        c.vm.network(:private_network, :ip=>"192.168.33.33")
       RUBY
     end
 

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -81,7 +81,7 @@ Vagrant.configure("2") do |c|
 <% end %>
 
 <% Array(config[:network]).each do |opts| %>
-  c.vm.network(:<%= opts[0] %>, <%= opts[1..-1].join(", ") %>)
+  c.vm.network(:<%= opts[0] %>, <%= opts[1].to_s.delete_prefix('{').delete_suffix('}') %>)
 <% end %>
 
   c.vm.synced_folder ".", "/vagrant", disabled: true


### PR DESCRIPTION

# Description

The final Vagrant file should be compatible with Ruby 2.7 and 3,
so it should look like that:

```diff
- c.vm.network(:forwarded_port, {:guest=>443, :host=>2443})
+ c.vm.network(:forwarded_port, :guest=>443, :host=>2443)
```

## Issues Resolved

#476

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
