### PR TITLE
add provider to update and prune commands

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -313,14 +313,14 @@ module Kitchen
       def finalize_box_auto_update!
         return if config[:box_auto_update].nil?
 
-        config[:box_auto_update] = "vagrant box update #{"--insecure " if config[:box_download_insecure]}--box #{config[:box]}"
+        config[:box_auto_update] = "vagrant box update #{"--insecure " if config[:box_download_insecure]}--box #{config[:box]} --provider #{config[:provider]}"
       end
 
       # Create vagrant command to remove older versions of the box
       def finalize_box_auto_prune!
         return if config[:box_auto_prune].nil?
 
-        config[:box_auto_prune] = "vagrant box prune --keep-active-boxes --name #{config[:box]}"
+        config[:box_auto_prune] = "vagrant box prune --keep-active-boxes --name #{config[:box]} --provider #{config[:provider]}"
       end
 
       # Replaces any `{{vagrant_root}}` tokens in the pre create command.


### PR DESCRIPTION
Signed-off-by: Corey Hemminger <hemminger@hotmail.com>

# Description

This is required if you have multiple boxes of the same name from multiple providers such as virtualbox and parallels. Without the provider flag it throws an error not knowing which one to update or prune. Adding the flag doesn't change original behavior either.

## Type of Change

bugfix

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
