### PR TITLE
_feat_: add arm64 to bento box name

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -125,7 +125,7 @@ module Kitchen
       # @return [String,nil] the Vagrant box for this Instance
       def default_box
         if bento_box?(instance.platform.name)
-          "bento/#{instance.platform.name}#{'-arm64' if RbConfig::CONFIG["host_cpu"].eql?('arm64')}"
+          "bento/#{instance.platform.name}#{"-arm64" if RbConfig::CONFIG["host_cpu"].eql?("arm64")}"
         else
           instance.platform.name
         end

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -125,7 +125,7 @@ module Kitchen
       # @return [String,nil] the Vagrant box for this Instance
       def default_box
         if bento_box?(instance.platform.name)
-          "bento/#{instance.platform.name}"
+          "bento/#{instance.platform.name}#{'-arm64' if RbConfig::CONFIG["host_cpu"].eql?('arm64')}"
         else
           instance.platform.name
         end


### PR DESCRIPTION
# Description

adds `-arm64` to bento box name automatically if on an arm64 cpu host

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
