### PR TITLE
_fix_add force for prune command

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -320,7 +320,7 @@ module Kitchen
       def finalize_box_auto_prune!
         return if config[:box_auto_prune].nil?
 
-        config[:box_auto_prune] = "vagrant box prune --keep-active-boxes --name #{config[:box]} --provider #{config[:provider]}"
+        config[:box_auto_prune] = "vagrant box prune --force --keep-active-boxes --name #{config[:box]} --provider #{config[:provider]}"
       end
 
       # Replaces any `{{vagrant_root}}` tokens in the pre create command.


### PR DESCRIPTION
# Description

When an older box version is still in use by a vagrant box the prune command then prompts for user input to continue after warning of box that is older but in use  but throws an error since their is no tty attached. This forces it to continue with prune and not prompt. Older boxes that are still associated with active vagrant machines are not removed.
