### PR TITLE
add vagrant architecture support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ required.
 
 ### Vagrant
 
-A Vagrant version of 1.6 or later.
+A Vagrant version of 2.4 or later.
 
 ## Installation
 

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -321,7 +321,6 @@ module Kitchen
         return if config[:box_auto_prune].nil?
 
         cmd = "#{config[:vagrant_binary]} box prune --force --keep-active-boxes --name #{config[:box]}"
-        cmd += " --architecture #{config[:box_arch]}" if config[:box_arch]
         cmd += " --provider #{config[:provider]}" if config[:provider]
         config[:box_auto_prune] = cmd
       end

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -226,7 +226,7 @@ module Kitchen
 
       protected
 
-      WEBSITE = "https://www.vagrantup.com/downloads.html".freeze
+      WEBSITE = "https://developer.hashicorp.com/vagrant/install".freeze
       MIN_VER = "2.4.0".freeze
 
       class << self

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -56,6 +56,8 @@ module Kitchen
 
       default_config :box_version, nil
 
+      default_config :box_arch, nil
+
       default_config :boot_timeout, nil
 
       default_config :customize, {}
@@ -125,7 +127,7 @@ module Kitchen
       # @return [String,nil] the Vagrant box for this Instance
       def default_box
         if bento_box?(instance.platform.name)
-          "bento/#{instance.platform.name}#{"-arm64" if RbConfig::CONFIG["host_cpu"].eql?("arm64")}"
+          "bento/#{instance.platform.name}"
         else
           instance.platform.name
         end
@@ -225,7 +227,7 @@ module Kitchen
       protected
 
       WEBSITE = "https://www.vagrantup.com/downloads.html".freeze
-      MIN_VER = "1.1.0".freeze
+      MIN_VER = "2.4.0".freeze
 
       class << self
 
@@ -313,14 +315,21 @@ module Kitchen
       def finalize_box_auto_update!
         return if config[:box_auto_update].nil?
 
-        config[:box_auto_update] = "vagrant box update #{"--insecure " if config[:box_download_insecure]}--box #{config[:box]} --provider #{config[:provider]}"
+        cmd = "#{config[:vagrant_binary]} box update --box #{config[:box]}"
+        cmd += " --architecture #{config[:box_arch]}" if config[:box_arch]
+        cmd += " --provider #{config[:provider]}" if config[:provider]
+        cmd += " --insecure" if config[:box_download_insecure]
+        config[:box_auto_update] = cmd
       end
 
       # Create vagrant command to remove older versions of the box
       def finalize_box_auto_prune!
         return if config[:box_auto_prune].nil?
 
-        config[:box_auto_prune] = "vagrant box prune --force --keep-active-boxes --name #{config[:box]} --provider #{config[:provider]}"
+        cmd = "#{config[:vagrant_binary]} box prune --force --keep-active-boxes --name #{config[:box]}"
+        cmd += " --architecture #{config[:box_arch]}" if config[:box_arch]
+        cmd += " --provider #{config[:provider]}" if config[:provider]
+        config[:box_auto_prune] = cmd
       end
 
       # Replaces any `{{vagrant_root}}` tokens in the pre create command.

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -542,7 +542,7 @@ describe Kitchen::Driver::Vagrant do
       with_unsupported_vagrant
 
       expect { driver.verify_dependencies }.to raise_error(
-        Kitchen::UserError, /Please upgrade to version 1.1.0 or higher/
+        Kitchen::UserError, /Please upgrade to version 2.4.0 or higher/
       )
     end
 
@@ -551,7 +551,7 @@ describe Kitchen::Driver::Vagrant do
         .with("vagrant --version", any_args).and_raise(Errno::ENOENT)
 
       expect { driver.verify_dependencies }.to raise_error(
-        Kitchen::UserError, /Vagrant 1.1.0 or higher is not installed/
+        Kitchen::UserError, /Vagrant 2.4.0 or higher is not installed/
       )
     end
   end

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -2139,7 +2139,7 @@ describe Kitchen::Driver::Vagrant do
   end
 
   def with_modern_vagrant
-    with_vagrant("1.7.2")
+    with_vagrant("2.4.1")
   end
 
   def with_unsupported_vagrant

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -79,7 +79,6 @@ describe Kitchen::Driver::Vagrant do
   before(:each) { stub_const("ENV", env) }
 
   after do
-    driver_object.class.send(:winrm_plugin_passed=, nil)
     driver_object.class.send(:vagrant_version=, nil)
   end
 
@@ -553,69 +552,6 @@ describe Kitchen::Driver::Vagrant do
       expect { driver.verify_dependencies }.to raise_error(
         Kitchen::UserError, /Vagrant 2.4.0 or higher is not installed/
       )
-    end
-  end
-
-  describe "#load_needed_dependencies!" do
-
-    describe "with winrm transport" do
-
-      before { allow(transport).to receive(:name).and_return("WinRM") }
-
-      it "old version of Vagrant raises UserError" do
-        with_vagrant("1.5.0")
-
-        expect { instance }.to raise_error(
-          Kitchen::Error, /Please upgrade to version 1.6 or higher/
-        )
-      end
-
-      it "modern vagrant without plugin installed raises UserError" do
-        with_modern_vagrant
-        allow(driver_object).to receive(:run_command)
-          .with("vagrant plugin list", any_args).and_return("nope (1.2.3)")
-
-        expect { instance }.to raise_error(
-          Kitchen::Error, /vagrant plugin install vagrant-winrm/
-        )
-      end
-
-      it "modern vagrant with plugin installed succeeds" do
-        with_modern_vagrant
-        allow(driver_object).to receive(:run_command)
-          .with("vagrant plugin list", any_args)
-          .and_return("vagrant-winrm (1.2.3)")
-
-        instance
-      end
-    end
-
-    describe "without winrm transport" do
-
-      before { allow(transport).to receive(:name).and_return("Anything") }
-
-      it "old version of Vagrant succeeds" do
-        with_vagrant("1.5.0")
-
-        instance
-      end
-
-      it "modern vagrant without plugin installed succeeds" do
-        with_modern_vagrant
-        allow(driver_object).to receive(:run_command)
-          .with("vagrant plugin list", any_args).and_return("nope (1.2.3)")
-
-        instance
-      end
-
-      it "modern vagrant with plugin installed succeeds" do
-        with_modern_vagrant
-        allow(driver_object).to receive(:run_command)
-          .with("vagrant plugin list", any_args)
-          .and_return("vagrant-winrm (1.2.3)")
-
-        instance
-      end
     end
   end
 

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -20,6 +20,10 @@ Vagrant.configure("2") do |c|
   c.vm.box_version = "<%= config[:box_version] %>"
 <% end %>
 
+<% if config[:box_arch] %>
+  c.vm.box_architecture = "<%= config[:box_arch] %>"
+<% end %>
+
 <% if !config[:box_check_update].nil? %>
   c.vm.box_check_update = <%= config[:box_check_update] %>
 <% end %>


### PR DESCRIPTION
# Description

added vagrant cpu architecture support when specifying boxes and providers
https://developer.hashicorp.com/vagrant/vagrant-cloud/boxes/architecture
https://app.vagrantup.com/bento/boxes/ubuntu-23.10

When not specified Vagrant defaults to the system CPU architecture for box downloads

## Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
