### PR TITLE
feat: support setting extra data for VirtualBox

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1483,6 +1483,26 @@ describe Kitchen::Driver::Vagrant do
           end
         RUBY
       end
+
+      it "adds lines for multiple setextradata in :customize and quotes only string values" do
+        config[:customize] = {
+          setextradata: {
+            "VBoxInternal/Devices/smc/0/Config/GetKeyFromRealSMC": 0,
+            "VBoxInternal/Devices/efi/0/Config/DmiSystemVersion": "1.0"
+          },
+        }
+        cmd
+
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
+          c.vm.provider :virtualbox do |p|
+            p.name = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
+            p.customize ["modifyvm", :id, "--audio", "none"]
+            p.customize ["setextradata", :id, "VBoxInternal/Devices/smc/0/Config/GetKeyFromRealSMC", 0] 
+            p.customize ["setextradata", :id, "VBoxInternal/Devices/efi/0/Config/DmiSystemVersion", "1.0"] 
+          end
+        RUBY
+      end
+
     end
 
     context "for parallels provider" do

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -201,6 +201,11 @@ Vagrant.configure("2") do |c|
            ids << "\"#{id}\""
          end %>
     p.customize ["modifyvm", :id, "--cpuidset", <%= ids.join(', ') %>]
+    <% elsif key == :setextradata %>
+      <% value.each do | data_key, data_value |  %>
+      <% data_value = "\"#{data_value}\"" if data_value.is_a? String %>
+    p.customize ["setextradata", :id, "<%= data_key %>", <%= data_value %>] 
+      <% end %>
     <% else %>
     p.customize ["modifyvm", :id, "--<%= key %>", "<%= value %>"]
     <% end %>


### PR DESCRIPTION
# Description

VirtualBox supports supplying VMs with additional data using the `setextradata` command in `VBoxManage`. Setting data here is sometimes necessary to get guests to boot on unfamiliar systems (such as by telling the guest not to try to read SMC data from the host).

As this is VirtualBox-specific, it's implemented using a magic value to the `customize` block.

## Issues Resolved

## Type of Change

`feat` (non-breaking new feature)

## Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
