### PR TITLE
Make libvirt guest name as closer as virtualbox and hyperv does avoiding name conflicts in shared libvirt environments.

### DIFF
--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -126,6 +126,8 @@ Vagrant.configure("2") do |c|
 <% config[:customize].each do |key, value| %>
   <% case config[:provider]
      when "libvirt" %>
+    p.default_prefix = '<%="kitchen-#{File.basename(config[:kitchen_root])}-#{instance.name}-"%>'
+    p.random_hostname = true
     <% if key == :storage %>
       <% if value.is_a? String %>
     p.storage <%= value %>


### PR DESCRIPTION
This change avoids having multiple persons working on a server with a shared libvirt when using test-kitchen with platforms and suites of the same name to block another from creating the kitchen machine due to colliding names.

