### PR TITLE
fix: Avoid colliding guest names on libvirt when running multiple kit…

### DIFF
--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1619,8 +1619,9 @@ describe Kitchen::Driver::Vagrant do
         }
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :libvirt do |p|
+            p.default_prefix = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.a_key = "some value"
             p.something = "else"
             p.a_number_key = 1024
@@ -1634,8 +1635,9 @@ describe Kitchen::Driver::Vagrant do
         }
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :libvirt do |p|
+            p.default_prefix = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.storage :file, :size => '32G'
           end
         RUBY
@@ -1651,8 +1653,9 @@ describe Kitchen::Driver::Vagrant do
         }
         cmd
 
-        expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
+        expect(vagrantfile).to match(Regexp.new(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :libvirt do |p|
+            p.default_prefix = "kitchen-#{File.basename(config[:kitchen_root])}-suitey-fooos-99-.*"
             p.storage :file, :size => '1G'
             p.storage :file, :size => '128G', :bus => 'sata'
             p.storage :file, :size => '64G', :bus => 'sata'

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -126,6 +126,7 @@ Vagrant.configure("2") do |c|
 <% config[:customize].each do |key, value| %>
   <% case config[:provider]
      when "libvirt" %>
+    p.default_prefix = "kitchen-<%= File.basename(config[:kitchen_root]) %>-<%= instance.name %>-<%= SecureRandom.uuid %>"
     <% if key == :storage %>
       <% if value.is_a? String %>
     p.storage <%= value %>


### PR DESCRIPTION
This change avoids colllision in guest names on libvirt when using a shared development server, by setting a default_prefix on vagrant-libvirt that names the guest as closely possible as vagrant and hyperv behaviour.

## Issues Resolved

## Type of Change

fix (non-breaking) as it was throughly tested on our enviroment.

## Check List

- [X] New functionality includes tests
- [X] All tests pass
- [X] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
