### PR TITLE
fix: Add utm provider to list of not safe providers for omnibus cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     name: Kitchen Verify
     strategy:
       matrix:
-        ruby: ["3.3"]
+        ruby: ["3.4"]
         os: ["almalinux-9"]
     steps:
       - name: Install Vagrant VirtualBox
@@ -24,7 +24,7 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           echo "deb [signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
           sudo apt-get update
-          sudo apt-get install -y software-properties-common vagrant virtualbox-7.0
+          sudo apt-get install -y software-properties-common vagrant virtualbox-7.2
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 ---
 require:
-  - chefstyle
+  - cookstyle
 
 AllCops:
   Include:

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,5 @@ group :debug do
 end
 
 group :cookstyle do
-  gem "cookstyle", "2.2.3"
+  gem "cookstyle"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,6 @@ group :debug do
   gem "pry"
 end
 
-group :chefstyle do
-  gem "chefstyle", "2.2.3"
+group :cookstyle do
+  gem "cookstyle", "2.2.3"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -7,13 +7,13 @@ RSpec::Core::RakeTask.new(:test) do |t|
 end
 
 begin
-  require "chefstyle"
+  require "cookstyle"
   require "rubocop/rake_task"
   RuboCop::RakeTask.new(:style) do |task|
     task.options += ["--display-cop-names", "--no-color"]
   end
 rescue LoadError
-  puts "chefstyle is not available. (sudo) gem install chefstyle to do style checking."
+  puts "cookstyle is not available. (sudo) gem install cookstyle to do style checking."
 end
 
 task default: %i{test style}

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -252,9 +252,9 @@ module Kitchen
       #   shared folders
       # @api private
       def safe_share?(box)
-        return false if /(hyperv|libvirt)/.match?(config[:provider])
+        return false if /(hyperv|libvirt|qemu|utm)/.match?(config[:provider])
 
-        box =~ %r{^bento/(centos|debian|fedora|opensuse|ubuntu|oracle|amazonlinux|almalinux|rockylinux|springdalelinux)-}
+        box =~ %r{^bento/(centos-stream|debian|fedora|opensuse|ubuntu|oraclelinux|amazonlinux|almalinux|rockylinux)-}
       end
 
       # Return true if we found the criteria to enable the cache_directory

--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -254,7 +254,7 @@ module Kitchen
       def safe_share?(box)
         return false if /(hyperv|libvirt|qemu|utm)/.match?(config[:provider])
 
-        box =~ %r{^bento/(centos-stream|debian|fedora|opensuse|ubuntu|oraclelinux|amazonlinux|almalinux|rockylinux)-}
+        box =~ %r{^bento/(centos|debian|fedora|opensuse|ubuntu|oracle|amazonlinux|almalinux|rockylinux|springdalelinux)-}
       end
 
       # Return true if we found the criteria to enable the cache_directory


### PR DESCRIPTION
# Description

adding utm and qemu to list of providers not safe to use omnibus  cache as a shared folder. Those providers use qemu and try to mount as 9p file system. All RHEL variantes don't support 9p filesystem and requires recompiling of kernel to enable kernel modules or installing kernel from elrepo which defeats having a standard rhel based install.

Fix cookstyle linting

## Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
