### PR TITLE
fix: update hash syntax for Ruby 3.4 compatibility

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,22 +17,24 @@ jobs:
         ruby: ["3.4"]
         os: ["almalinux-9"]
     steps:
-      - name: Install Vagrant VirtualBox
+      - name: Install VirtualBox
         run: |
-          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | gpg --dearmor | sudo tee /usr/share/keyrings/oracle-virtualbox-2016.gpg
-          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          echo "deb [signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
           sudo apt-get update
-          sudo apt-get install -y software-properties-common vagrant virtualbox-7.2
+          sudo apt-get install -y software-properties-common libarchive-tools virtualbox
       - uses: actions/checkout@v5
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Install Vagrant
+        run: |
+          bundle add vagrant --version ">= 2.4.4"
+          bundle binstubs vagrant
+          export PATH="$(pwd)/bin:$PATH"
+          vagrant -v
       - name: Kitchen Verify
         run: |
-          export LOGNAME=$USER
+          export PATH="$(pwd)/bin:$PATH"
           bundle exec kitchen verify default-${{ matrix.os}}
         env:
           CHEF_LICENSE: "accept-no-persist"

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ begin
   require "cookstyle"
   require "rubocop/rake_task"
   RuboCop::RakeTask.new(:style) do |task|
-    task.options += ["--display-cop-names", "--no-color"]
+    task.options += ["--chefstyle", "--display-cop-names", "--no-color"]
   end
 rescue LoadError
   puts "cookstyle is not available. (sudo) gem install cookstyle to do style checking."

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1177,8 +1177,8 @@ describe Kitchen::Driver::Vagrant do
       cmd
 
       expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {6}/, "").chomp))
-        c.vm.network(:forwarded_port, "guest": 80, "host": 8080)
-        c.vm.network(:private_network, "ip": "192.168.33.33")
+        c.vm.network(:forwarded_port, guest: 80, host: 8080)
+        c.vm.network(:private_network, ip: "192.168.33.33")
       RUBY
     end
 
@@ -1955,10 +1955,10 @@ describe Kitchen::Driver::Vagrant do
 
         expectation = <<-RUBY.gsub(/^ {8}/, "").gsub(/,\n     /, ",").chomp
           c.vm.provider :cloudstack do |p|
-            p.firewall_rules = [{"ipaddress": "A.A.A.A", "cidrlist": "B.B.B.B/24",
-              "protocol": "tcp", "startport": 2222,
-              "endport": 2222}, {"ipaddress": "C.C.C.C", "cidrlist": "D.D.D.D/32",
-              "protocol": "tcp", "startport": 80, "endport": 81}]
+            p.firewall_rules = [{ipaddress: "A.A.A.A", cidrlist: "B.B.B.B/24",
+              protocol: "tcp", startport: 2222,
+              endport: 2222}, {ipaddress: "C.C.C.C", cidrlist: "D.D.D.D/32",
+              protocol: "tcp", startport: 80, endport: 81}]
           end
         RUBY
 
@@ -2028,12 +2028,12 @@ describe Kitchen::Driver::Vagrant do
 
         expectation = <<-RUBY.gsub(/^ {8}/, "").gsub(/,\n     /, ",").chomp
           c.vm.provider :cloudstack do |p|
-            p.security_groups = [{"name": "Awesome_security_group",
-              "description": "Created from the Vagrantfile",
-              "rules": [{"type": "ingress", "protocol": "TCP", "startport": 22,
-              "endport": 22, "cidrlist": "0.0.0.0/0"}, {"type": "egress",
-              "protocol": "TCP", "startport": 81, "endport": 82,
-              "cidrlist": "1.2.3.4/24"}]}]
+            p.security_groups = [{name: "Awesome_security_group",
+              description: "Created from the Vagrantfile",
+              rules: [{type: "ingress", protocol: "TCP", startport: 22,
+              endport: 22, cidrlist: "0.0.0.0/0"}, {type: "egress",
+              protocol: "TCP", startport: 81, endport: 82,
+              cidrlist: "1.2.3.4/24"}]}]
           end
         RUBY
 
@@ -2048,7 +2048,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :cloudstack do |p|
-            p.static_nat = [{"idaddress": "A.A.A.A"}]
+            p.static_nat = [{idaddress: "A.A.A.A"}]
           end
         RUBY
       end
@@ -2076,10 +2076,10 @@ describe Kitchen::Driver::Vagrant do
 
         expectation = <<-RUBY.gsub(/^ {8}/, "").gsub(/,\n     /, ",").chomp
           c.vm.provider :cloudstack do |p|
-            p.port_forwarding_rules = [{"ipaddress": "X.X.X.X",
-              "protocol": "tcp", "publicport": 22, "privateport": 22,
-              "openfirewall": false}, {"ipaddress": "X.X.X.X", "protocol": "tcp",
-              "publicport": 80, "privateport": 80, "openfirewall": false}]
+            p.port_forwarding_rules = [{ipaddress: "X.X.X.X",
+              protocol: "tcp", publicport: 22, privateport: 22,
+              openfirewall: false}, {ipaddress: "X.X.X.X", protocol: "tcp",
+              publicport: 80, privateport: 80, openfirewall: false}]
           end
         RUBY
 

--- a/spec/kitchen/driver/vagrant_spec.rb
+++ b/spec/kitchen/driver/vagrant_spec.rb
@@ -1177,8 +1177,8 @@ describe Kitchen::Driver::Vagrant do
       cmd
 
       expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {6}/, "").chomp))
-        c.vm.network(:forwarded_port, :guest=>80, :host=>8080)
-        c.vm.network(:private_network, :ip=>"192.168.33.33")
+        c.vm.network(:forwarded_port, "guest": 80, "host": 8080)
+        c.vm.network(:private_network, "ip": "192.168.33.33")
       RUBY
     end
 
@@ -1606,7 +1606,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :softlayer do |p|
-            p.disk_capacity = {:"0"=>25, :"2"=>100}
+            p.disk_capacity = {"0": 25, "2": 100}
           end
         RUBY
       end
@@ -1955,10 +1955,10 @@ describe Kitchen::Driver::Vagrant do
 
         expectation = <<-RUBY.gsub(/^ {8}/, "").gsub(/,\n     /, ",").chomp
           c.vm.provider :cloudstack do |p|
-            p.firewall_rules = [{:ipaddress=>"A.A.A.A", :cidrlist=>"B.B.B.B/24",
-              :protocol=>"tcp", :startport=>2222,
-              :endport=>2222}, {:ipaddress=>"C.C.C.C", :cidrlist=>"D.D.D.D/32",
-              :protocol=>"tcp", :startport=>80, :endport=>81}]
+            p.firewall_rules = [{"ipaddress": "A.A.A.A", "cidrlist": "B.B.B.B/24",
+              "protocol": "tcp", "startport": 2222,
+              "endport": 2222}, {"ipaddress": "C.C.C.C", "cidrlist": "D.D.D.D/32",
+              "protocol": "tcp", "startport": 80, "endport": 81}]
           end
         RUBY
 
@@ -2028,12 +2028,12 @@ describe Kitchen::Driver::Vagrant do
 
         expectation = <<-RUBY.gsub(/^ {8}/, "").gsub(/,\n     /, ",").chomp
           c.vm.provider :cloudstack do |p|
-            p.security_groups = [{:name=>"Awesome_security_group",
-              :description=>"Created from the Vagrantfile",
-              :rules=>[{:type=>"ingress", :protocol=>"TCP", :startport=>22,
-              :endport=>22, :cidrlist=>"0.0.0.0/0"}, {:type=>"egress",
-              :protocol=>"TCP", :startport=>81, :endport=>82,
-              :cidrlist=>"1.2.3.4/24"}]}]
+            p.security_groups = [{"name": "Awesome_security_group",
+              "description": "Created from the Vagrantfile",
+              "rules": [{"type": "ingress", "protocol": "TCP", "startport": 22,
+              "endport": 22, "cidrlist": "0.0.0.0/0"}, {"type": "egress",
+              "protocol": "TCP", "startport": 81, "endport": 82,
+              "cidrlist": "1.2.3.4/24"}]}]
           end
         RUBY
 
@@ -2048,7 +2048,7 @@ describe Kitchen::Driver::Vagrant do
 
         expect(vagrantfile).to match(regexify(<<-RUBY.gsub(/^ {8}/, "").chomp))
           c.vm.provider :cloudstack do |p|
-            p.static_nat = [{:idaddress=>"A.A.A.A"}]
+            p.static_nat = [{"idaddress": "A.A.A.A"}]
           end
         RUBY
       end
@@ -2076,10 +2076,10 @@ describe Kitchen::Driver::Vagrant do
 
         expectation = <<-RUBY.gsub(/^ {8}/, "").gsub(/,\n     /, ",").chomp
           c.vm.provider :cloudstack do |p|
-            p.port_forwarding_rules = [{:ipaddress=>"X.X.X.X",
-              :protocol=>"tcp", :publicport=>22, :privateport=>22,
-              :openfirewall=>false}, {:ipaddress=>"X.X.X.X", :protocol=>"tcp",
-              :publicport=>80, :privateport=>80, :openfirewall=>false}]
+            p.port_forwarding_rules = [{"ipaddress": "X.X.X.X",
+              "protocol": "tcp", "publicport": 22, "privateport": 22,
+              "openfirewall": false}, {"ipaddress": "X.X.X.X", "protocol": "tcp",
+              "publicport": 80, "privateport": 80, "openfirewall": false}]
           end
         RUBY
 

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -85,7 +85,7 @@ Vagrant.configure("2") do |c|
 <% end %>
 
 <% Array(config[:network]).each do |opts| %>
-  c.vm.network(:<%= opts[0] %>, <%= opts[1].to_s.delete_prefix('{').delete_suffix('}') %>)
+  c.vm.network(:<%= opts[0] %>, <%= JSON.parse(opts[1].to_json).to_s.delete_prefix('{').delete_suffix('}') %>)
 <% end %>
 
   c.vm.synced_folder ".", "/vagrant", disabled: true
@@ -137,6 +137,8 @@ Vagrant.configure("2") do |c|
     <% else %>
       <% if value.is_a? String %>
     p.<%= key %> = "<%= value%>"
+      <% elsif value.is_a? Hash %>
+    p.<%= key %> = <%= JSON.parse(value.to_json).to_s %>
       <% else %>
     p.<%= key %> = <%= value%>
       <% end %>
@@ -169,7 +171,7 @@ Vagrant.configure("2") do |c|
     <% end %>
   <% when "softlayer" %>
     <% if key == :disk_capacity %>
-    p.<%= key %> = <%= value %>
+    p.<%= key %> = <%= JSON.parse(value.to_json).to_s %>
     <% else %>
     p.<%= key %> = "<%= value %>"
     <% end %>
@@ -204,7 +206,7 @@ Vagrant.configure("2") do |c|
     <% elsif key == :setextradata %>
       <% value.each do | data_key, data_value |  %>
       <% data_value = "\"#{data_value}\"" if data_value.is_a? String %>
-    p.customize ["setextradata", :id, "<%= data_key %>", <%= data_value %>] 
+    p.customize ["setextradata", :id, "<%= data_key %>", <%= data_value %>]
       <% end %>
     <% else %>
     p.customize ["modifyvm", :id, "--<%= key %>", "<%= value %>"]
@@ -224,6 +226,8 @@ Vagrant.configure("2") do |c|
   <% else %>
     <% if value.is_a? String %>
     p.<%= key %> = "<%= value%>"
+    <% elsif value.is_a? Hash %>
+    p.<%= key %> = <%= JSON.parse(value.to_json).to_s %>
     <% else  %>
     p.<%= key %> = <%= value%>
     <% end  %>

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -85,7 +85,7 @@ Vagrant.configure("2") do |c|
 <% end %>
 
 <% Array(config[:network]).each do |opts| %>
-  c.vm.network(:<%= opts[0] %>, <%= JSON.parse(opts[1].to_json).to_s.delete_prefix('{').delete_suffix('}') %>)
+  c.vm.network(:<%= opts[0] %>, <%= opts[1].map { |k, v| "#{k}: #{v.inspect}" }.join(', ') %>)
 <% end %>
 
   c.vm.synced_folder ".", "/vagrant", disabled: true
@@ -131,14 +131,12 @@ Vagrant.configure("2") do |c|
     p.storage <%= value %>
       <% elsif value.is_a? Array %>
         <% value.each do |v| %>
-    p.storage <%= v %>
+          p.storage <%= v %>
         <% end %>
       <% end %>
     <% else %>
       <% if value.is_a? String %>
     p.<%= key %> = "<%= value%>"
-      <% elsif value.is_a? Hash %>
-    p.<%= key %> = <%= JSON.parse(value.to_json).to_s %>
       <% else %>
     p.<%= key %> = <%= value%>
       <% end %>
@@ -171,7 +169,11 @@ Vagrant.configure("2") do |c|
     <% end %>
   <% when "softlayer" %>
     <% if key == :disk_capacity %>
-    p.<%= key %> = <%= JSON.parse(value.to_json).to_s %>
+      <% if value.is_a? Hash %>
+    p.<%= key %> = {<%= value.map { |k, v| "\"#{k}\": #{v}" }.join(', ') %>}
+      <% else %>
+    p.<%= key %> = <%= value %>
+      <% end %>
     <% else %>
     p.<%= key %> = "<%= value %>"
     <% end %>
@@ -226,13 +228,29 @@ Vagrant.configure("2") do |c|
   <% else %>
     <% if value.is_a? String %>
     p.<%= key %> = "<%= value%>"
-    <% elsif value.is_a? Hash %>
-    p.<%= key %> = <%= JSON.parse(value.to_json).to_s %>
+    <% elsif value.is_a? Array %>
+      <% if value.all? { |item| item.is_a? Hash } %>
+        <%
+          def format_hash_recursively(hash)
+            hash.map do |k, v|
+              if v.is_a?(Array) && v.all? { |item| item.is_a? Hash }
+                # Handle nested array of hashes
+                formatted_array = v.map { |nested_hash| "{" + format_hash_recursively(nested_hash) + "}" }.join(", ")
+                "#{k}: [#{formatted_array}]"
+              else
+                "#{k}: #{v.inspect}"
+              end
+            end.join(", ")
+          end
+        %>
+    p.<%= key %> = [<%= value.map { |hash| "{" + format_hash_recursively(hash) + "}" }.join(", ") %>]
+      <% else %>
+    p.<%= key %> = <%= value%>
+      <% end %>
     <% else  %>
     p.<%= key %> = <%= value%>
     <% end  %>
   <% end %>
 <% end %>
   end
-
 end

--- a/templates/Vagrantfile.erb
+++ b/templates/Vagrantfile.erb
@@ -131,7 +131,7 @@ Vagrant.configure("2") do |c|
     p.storage <%= value %>
       <% elsif value.is_a? Array %>
         <% value.each do |v| %>
-          p.storage <%= v %>
+    p.storage <%= v %>
         <% end %>
       <% end %>
     <% else %>


### PR DESCRIPTION
* Use JSON.parse(value.to_json).to_s approach to ensure consistent hash
  string representation across Ruby versions
* Update test expectations to use modern {"key": value} JSON-style syntax
* Fixes test failures occurring with Ruby 3.4's updated hash.to_s behavior

Signed-off-by: Dan Webb <dan.webb@damacus.io>
