### PR TITLE
fix: add oracle linux to bento box list

### DIFF
--- a/lib/kitchen/driver/vagrant.rb
+++ b/lib/kitchen/driver/vagrant.rb
@@ -243,7 +243,7 @@ module Kitchen
       #   box
       # @api private
       def bento_box?(name)
-        name =~ /^(centos|debian|fedora|freebsd|opensuse|ubuntu|oracle|hardenedbsd|amazonlinux|almalinux|rockylinux|springdalelinux)-/
+        name =~ /^(centos|debian|fedora|freebsd|opensuse|ubuntu|oracle|oraclelinux|hardenedbsd|amazonlinux|almalinux|rockylinux|springdalelinux)-/
       end
 
       # Returns whether or not the we expect the box to work with shared folders
@@ -254,7 +254,7 @@ module Kitchen
       def safe_share?(box)
         return false if /(hyperv|libvirt|qemu|utm)/.match?(config[:provider])
 
-        box =~ %r{^bento/(centos|debian|fedora|opensuse|ubuntu|oracle|amazonlinux|almalinux|rockylinux|springdalelinux)-}
+        box =~ %r{^bento/(centos|debian|fedora|opensuse|ubuntu|oracle|oraclelinux|amazonlinux|almalinux|rockylinux|springdalelinux)-}
       end
 
       # Return true if we found the criteria to enable the cache_directory


### PR DESCRIPTION
this fixes errors when trying to use newer oraclelinux bento boxes

# Description

Please describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
